### PR TITLE
Pylon persistent data container

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlock.kt
@@ -1,17 +1,17 @@
 package io.github.pylonmc.pylon.core.block
 
+import io.github.pylonmc.pylon.core.persistence.PylonDataReader
+import io.github.pylonmc.pylon.core.persistence.PylonDataWriter
 import io.github.pylonmc.pylon.core.registry.PylonRegistries
 import io.github.pylonmc.pylon.core.registry.PyonRegistryKeys
-import io.github.pylonmc.pylon.core.state.StateReader
-import io.github.pylonmc.pylon.core.state.StateWriter
 import org.bukkit.NamespacedKey
 import org.bukkit.block.Block
 
-open class PylonBlock<S : PylonBlockSchema> private constructor(val schema: S, val block: Block) {
-    constructor(stateReader: StateReader, block: Block)
-            : this(getSchemaOfType<S>(stateReader.id), block)
+open class PylonBlock<S: PylonBlockSchema> private constructor(val schema: S, val block: Block) {
+    constructor(reader: PylonDataReader, block: Block)
+            : this(getSchemaOfType<S>(reader.id), block)
 
-    fun write(writer: StateWriter) {}
+    fun write(writer: PylonDataWriter) {}
 
     // TODO listener
     fun tick() {}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlockSchema.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlockSchema.kt
@@ -1,8 +1,8 @@
 package io.github.pylonmc.pylon.core.block
 
+import io.github.pylonmc.pylon.core.persistence.PylonDataReader
 import io.github.pylonmc.pylon.core.registry.PylonRegistries
 import io.github.pylonmc.pylon.core.registry.PyonRegistryKeys
-import io.github.pylonmc.pylon.core.state.StateReader
 import org.bukkit.Keyed
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
@@ -25,7 +25,7 @@ open class PylonBlockSchema(
     internal val loadConstructor: MethodHandle = try {
         MethodHandles.lookup().unreflectConstructor(
             blockClass.getConstructor(
-                StateReader::class.java,
+                PylonDataReader::class.java,
                 Block::class.java
             )
         )

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonDataReader.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonDataReader.kt
@@ -4,7 +4,9 @@ import org.bukkit.NamespacedKey
 import org.bukkit.persistence.PersistentDataType
 
 interface PylonDataReader {
-    // ID of the holder of this reader - for example the ID of a block
+    /**
+      * ID of the holder of this reader - for example the ID of a block
+      */
     val id: NamespacedKey
 
     fun <P : Any, C : Any> has(key: NamespacedKey, type: PersistentDataType<P, C>): Boolean

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonDataReader.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonDataReader.kt
@@ -1,0 +1,25 @@
+package io.github.pylonmc.pylon.core.persistence
+
+import org.bukkit.NamespacedKey
+import org.bukkit.persistence.PersistentDataType
+
+interface PylonDataReader {
+    // ID of the holder of this reader - for example the ID of a block
+    val id: NamespacedKey
+
+    fun <P : Any, C : Any> has(key: NamespacedKey, type: PersistentDataType<P, C>): Boolean
+
+    fun has(key: NamespacedKey): Boolean
+
+    fun <P : Any, C : Any> get(key: NamespacedKey, type: PersistentDataType<P, C>): C?
+
+    fun <P : Any, C : Any> getOrDefault(
+        key: NamespacedKey,
+        type: PersistentDataType<P, C>,
+        defaultValue: C
+    ): C
+
+    fun getKeys(): Set<NamespacedKey>
+
+    fun isEmpty(): Boolean
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonDataWriter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonDataWriter.kt
@@ -1,0 +1,8 @@
+package io.github.pylonmc.pylon.core.persistence
+
+import org.bukkit.NamespacedKey
+import org.bukkit.persistence.PersistentDataType
+
+interface PylonDataWriter {
+    fun <P : Any?, C : Any?> set(key: NamespacedKey, type: PersistentDataType<P, C>, value: C & Any)
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonPersistentDataContainer.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonPersistentDataContainer.kt
@@ -1,0 +1,210 @@
+package io.github.pylonmc.pylon.core.persistence
+
+import io.github.pylonmc.pylon.core.pluginInstance
+import org.bukkit.NamespacedKey
+import org.bukkit.persistence.PersistentDataAdapterContext
+import org.bukkit.persistence.PersistentDataContainer
+import org.bukkit.persistence.PersistentDataType
+import java.nio.ByteBuffer
+
+/*
+ * Pylon implementation of PersistentDataContainers (https://docs.papermc.io/paper/dev/pdc)
+ *
+ * This implementation is tailored toward serializing everything into bytes for external storage on disk.
+ *
+ * Any nested PDCs are assumed to be PylonPersistentDataContainers.
+ */
+internal class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataContainer, PylonDataReader, PylonDataWriter {
+    private val data: MutableMap<NamespacedKey, ByteArray> = HashMap()
+
+    init {
+        readFromBytes(bytes)
+    }
+
+    /*
+     * Constructor that also sets the ID of this PDC's holder. This should be used for creating PDCs for
+     * holders such as blocks, but not for nested PDCs (they don't need ids)
+     */
+    constructor(id: NamespacedKey, bytes: ByteArray) : this(bytes) {
+        set(idKey, Serializers.NAMESPACED_KEY, id)
+    }
+
+    override val id
+        get() = get(idKey, Serializers.NAMESPACED_KEY)!!
+
+    private class PylonPersistentDataAdapterContext : PersistentDataAdapterContext {
+        override fun newPersistentDataContainer(): PersistentDataContainer
+                = PylonPersistentDataContainer(byteArrayOf())
+    }
+
+    override fun <P : Any, C : Any> has(key: NamespacedKey, type: PersistentDataType<P, C>): Boolean
+        = get(key, type) != null
+
+    override fun has(key: NamespacedKey): Boolean
+        = data.containsKey(key)
+
+    override fun <P : Any, C : Any> get(key: NamespacedKey, type: PersistentDataType<P, C>): C? {
+        val x = data[key] ?: return null
+        return type.fromPrimitive(bytesToPrimitive(type.primitiveType, x), PylonPersistentDataAdapterContext())
+    }
+
+    override fun <P : Any, C : Any> getOrDefault(
+        key: NamespacedKey,
+        type: PersistentDataType<P, C>,
+        defaultValue: C
+    ): C = get(key, type) ?: defaultValue
+
+    override fun getKeys(): Set<NamespacedKey>
+        = data.keys
+
+    override fun isEmpty(): Boolean
+        = data.isEmpty()
+
+    override fun copyTo(other: PersistentDataContainer, replace: Boolean) {
+        for ((key, entry) in data) {
+            if (!replace and other.has(key)) {
+                continue
+            }
+            other.set(key, PersistentDataType.BYTE_ARRAY, entry)
+        }
+    }
+
+    override fun getAdapterContext(): PersistentDataAdapterContext {
+        return PylonPersistentDataAdapterContext()
+    }
+
+    override fun serializeToBytes(): ByteArray {
+        val keysAsBytes = data.keys.map { key -> key.toString().toByteArray(Charsets.UTF_8) }
+        val bufferSize = keysAsBytes.zip(data.values).fold(0) { acc, (key, value) -> acc + 2 * Int.SIZE_BYTES + key.size + value.size }
+
+        val buffer = ByteBuffer.allocate(bufferSize)
+        for ((key, value) in keysAsBytes.zip(data.values)) {
+            buffer.putInt(key.size)
+            buffer.put(key)
+
+            buffer.putInt(value.size)
+            buffer.put(value)
+        }
+
+        return buffer.array()
+    }
+
+    override fun <P : Any?, C : Any?> set(key: NamespacedKey, type: PersistentDataType<P, C>, value: C & Any) {
+        data[key] = primitiveToBytes(type.primitiveType, type.toPrimitive(value, PylonPersistentDataAdapterContext()))
+    }
+
+    override fun remove(key: NamespacedKey) {
+        data.remove(key)
+    }
+
+    override fun readFromBytes(bytes: ByteArray, clear: Boolean) {
+        val buffer = ByteBuffer.wrap(bytes)
+        while (bytes.isEmpty()) {
+            val keyLength = buffer.getInt()
+            val keyBytes = ByteArray(keyLength)
+            buffer.get(keyBytes)
+            val key = NamespacedKey.fromString(keyBytes.toString(Charsets.UTF_8))!!
+
+            val valueLength = buffer.getInt()
+            val value = ByteArray(valueLength)
+            buffer.get(value)
+
+            data[key] = value
+        }
+    }
+
+    companion object {
+        val idKey = NamespacedKey(pluginInstance, "pylon_id")
+
+        private fun <T: Any?> primitiveToBytes(primitiveType: Class<T>, primitive: T): ByteArray
+            = when (primitiveType) {
+                Byte::class.java -> byteArrayOf(primitive as Byte)
+                Short::class.java -> ByteBuffer.allocate(Short.SIZE_BYTES).putShort(primitive as Short).array()
+                Integer::class.java -> ByteBuffer.allocate(Int.SIZE_BYTES).putInt(primitive as Int).array()
+                Long::class.java -> ByteBuffer.allocate(Long.SIZE_BYTES).putLong(primitive as Long).array()
+                Float::class.java -> ByteBuffer.allocate(Float.SIZE_BYTES).putFloat(primitive as Float).array()
+                Double::class.java -> ByteBuffer.allocate(Double.SIZE_BYTES).putDouble(primitive as Double).array()
+                String::class.java -> (primitive as String).toByteArray(Charsets.UTF_8)
+                ByteArray::class.java -> primitive as ByteArray
+                IntArray::class.java -> {
+                    val intArray = (primitive as IntArray)
+                    val bytes = ByteBuffer.allocate(intArray.size * Int.SIZE_BYTES)
+                    for (x in intArray) {
+                        bytes.putInt(x)
+                    }
+                    bytes.array()
+                }
+                LongArray::class.java -> {
+                    val intArray = (primitive as LongArray)
+                    val bytes = ByteBuffer.allocate(intArray.size * Long.SIZE_BYTES)
+                    for (x in intArray) {
+                        bytes.putLong(x)
+                    }
+                    bytes.array()
+                }
+                // This is PylonPersistentDataContainer here because when we get to deserializing PDCs, there is no way to know
+                // which implementor of PDC to serialize to. Therefore, we will only allow Pylon PDCs to be nested.
+                PersistentDataContainer::class.java -> (primitive as PylonPersistentDataContainer).serializeToBytes()
+                // TODO remove this, I think it's deprecated lol
+                Array<PersistentDataContainer>::class.java -> {
+                    @Suppress("UNCHECKED_CAST") // No way to check this cast
+                    val pdcArray = (primitive as Array<PersistentDataContainer>)
+                    val pdcsAsbytes = pdcArray.map { it.serializeToBytes() }
+                    val bufferSize = pdcsAsbytes.fold(0) { acc, bytes -> acc + Int.SIZE_BYTES + bytes.size }
+
+                    val buffer = ByteBuffer.allocate(bufferSize)
+                    for (pdc in pdcsAsbytes) {
+                        buffer.putInt(pdc.size)
+                        buffer.put(pdc)
+                    }
+
+                    buffer.array()
+                }
+                else -> error("Unrecognized primitive type")
+            }
+
+        // Sadly no way to 'switch' on the type T to avoid unchecked casting
+        // See https://stackoverflow.com/questions/73523156/how-to-overload-function-with-different-return-types-and-the-same-parameters-in
+        @Suppress("UNCHECKED_CAST")
+        private fun <T: Any?> bytesToPrimitive(primitiveType: Class<T>, bytes: ByteArray): T
+            = when (primitiveType) {
+                Byte::class.java -> bytes[0] as T
+                Short::class.java -> ByteBuffer.wrap(bytes).getShort() as T
+                Integer::class.java -> ByteBuffer.wrap(bytes).getInt() as T
+                Long::class.java -> ByteBuffer.wrap(bytes).getLong() as T
+                Float::class.java -> ByteBuffer.wrap(bytes).getFloat() as T
+                Double::class.java -> ByteBuffer.wrap(bytes).getDouble() as T
+                String::class.java -> bytes.toString(Charsets.UTF_8) as T
+                ByteArray::class.java -> bytes as T
+                IntArray::class.java -> {
+                    val buffer = ByteBuffer.wrap(bytes)
+                    var array = intArrayOf()
+                    while (buffer.hasRemaining()) {
+                        array += buffer.getInt()
+                    }
+                    array as T
+                }
+                LongArray::class.java -> {
+                    val buffer = ByteBuffer.wrap(bytes)
+                    var array = longArrayOf()
+                    while (buffer.hasRemaining()) {
+                        array += buffer.getLong()
+                    }
+                    array as T
+                }
+                PersistentDataContainer::class.java -> PylonPersistentDataContainer(bytes) as T
+                Array<PersistentDataContainer>::class.java -> {
+                    val buffer = ByteBuffer.wrap(bytes)
+                    val list: MutableList<PylonPersistentDataContainer> = mutableListOf()
+                    while (buffer.hasRemaining()) {
+                        val length = buffer.getInt()
+                        val value = ByteArray(length)
+                        buffer.get(value)
+                        list.add(PylonPersistentDataContainer(bytes))
+                    }
+                    list as T
+                }
+                else -> error("Unrecognized primitive type")
+            }
+    }
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonPersistentDataContainer.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonPersistentDataContainer.kt
@@ -144,7 +144,7 @@ internal class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataCo
                 // This is PylonPersistentDataContainer here because when we get to deserializing PDCs, there is no way to know
                 // which implementor of PDC to serialize to. Therefore, we will only allow Pylon PDCs to be nested.
                 PersistentDataContainer::class.java -> (primitive as PylonPersistentDataContainer).serializeToBytes()
-                else -> error("Unrecognized primitive type")
+                else -> error("Invalid primitive type '$primitiveType'")
             }
 
         // Sadly no way to 'switch' on the type T to avoid unchecked casting
@@ -177,7 +177,7 @@ internal class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataCo
                     array as T
                 }
                 PersistentDataContainer::class.java -> PylonPersistentDataContainer(bytes) as T
-                else -> error("Unrecognized primitive type")
+                else -> error("Invalid primitive type '$primitiveType'")
             }
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonPersistentDataContainer.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonPersistentDataContainer.kt
@@ -7,7 +7,7 @@ import org.bukkit.persistence.PersistentDataContainer
 import org.bukkit.persistence.PersistentDataType
 import java.nio.ByteBuffer
 
-/*
+/**
  * Pylon implementation of PersistentDataContainers (https://docs.papermc.io/paper/dev/pdc)
  *
  * This implementation is tailored toward serializing everything into bytes for external storage on disk.
@@ -21,7 +21,7 @@ internal class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataCo
         readFromBytes(bytes)
     }
 
-    /*
+    /**
      * Constructor that also sets the ID of this PDC's holder. This should be used for creating PDCs for
      * holders such as blocks, but not for nested PDCs (they don't need ids)
      */

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonPersistentDataContainer.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/PylonPersistentDataContainer.kt
@@ -2,6 +2,7 @@ package io.github.pylonmc.pylon.core.persistence
 
 import io.github.pylonmc.pylon.core.pluginInstance
 import org.bukkit.NamespacedKey
+import org.bukkit.persistence.ListPersistentDataType
 import org.bukkit.persistence.PersistentDataAdapterContext
 import org.bukkit.persistence.PersistentDataContainer
 import org.bukkit.persistence.PersistentDataType
@@ -14,12 +15,14 @@ import java.nio.ByteBuffer
  *
  * Any nested PDCs are assumed to be PylonPersistentDataContainers.
  */
-internal class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataContainer, PylonDataReader, PylonDataWriter {
+class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataContainer, PylonDataReader, PylonDataWriter {
     private val data: MutableMap<NamespacedKey, ByteArray> = HashMap()
 
     init {
         readFromBytes(bytes)
     }
+
+    constructor() : this(byteArrayOf())
 
     /**
      * Constructor that also sets the ID of this PDC's holder. This should be used for creating PDCs for
@@ -32,7 +35,7 @@ internal class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataCo
     override val id
         get() = get(idKey, Serializers.NAMESPACED_KEY)!!
 
-    private class PylonPersistentDataAdapterContext : PersistentDataAdapterContext {
+    class PylonPersistentDataAdapterContext : PersistentDataAdapterContext {
         override fun newPersistentDataContainer(): PersistentDataContainer
                 = PylonPersistentDataContainer(byteArrayOf())
     }
@@ -45,7 +48,7 @@ internal class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataCo
 
     override fun <P : Any, C : Any> get(key: NamespacedKey, type: PersistentDataType<P, C>): C? {
         val x = data[key] ?: return null
-        return type.fromPrimitive(bytesToPrimitive(type.primitiveType, x), adapterContext)
+        return type.fromPrimitive(bytesToPrimitive(type, x), adapterContext)
     }
 
     override fun <P : Any, C : Any> getOrDefault(
@@ -73,8 +76,13 @@ internal class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataCo
         = PylonPersistentDataAdapterContext()
 
     override fun serializeToBytes(): ByteArray {
-        val keysAsBytes = data.keys.map { key -> Serializers.NAMESPACED_KEY.toPrimitive(key, adapterContext) }
-        val bufferSize = keysAsBytes.zip(data.values).fold(0) { acc, (key, value) -> acc + 2 * Int.SIZE_BYTES + key.size + value.size }
+        val keysAsBytes = data.keys.map {
+            key -> Serializers.NAMESPACED_KEY.toPrimitive(key, adapterContext).toByteArray(Charsets.UTF_8)
+        }
+
+        val bufferSize = keysAsBytes.zip(data.values).fold(0) {
+            acc, (key, value) -> acc + 2 * Int.SIZE_BYTES + key.size + value.size
+        }
 
         val buffer = ByteBuffer.allocate(bufferSize)
         for ((key, value) in keysAsBytes.zip(data.values)) {
@@ -89,7 +97,7 @@ internal class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataCo
     }
 
     override fun <P : Any?, C : Any?> set(key: NamespacedKey, type: PersistentDataType<P, C>, value: C & Any) {
-        data[key] = primitiveToBytes(type.primitiveType, type.toPrimitive(value, adapterContext))
+        data[key] = primitiveToBytes(type, type.toPrimitive(value, adapterContext))
     }
 
     override fun remove(key: NamespacedKey) {
@@ -98,11 +106,11 @@ internal class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataCo
 
     override fun readFromBytes(bytes: ByteArray, clear: Boolean) {
         val buffer = ByteBuffer.wrap(bytes)
-        while (bytes.isEmpty()) {
+        while (buffer.hasRemaining()) {
             val keyLength = buffer.getInt()
             val keyBytes = ByteArray(keyLength)
             buffer.get(keyBytes)
-            val key = Serializers.NAMESPACED_KEY.fromPrimitive(keyBytes, adapterContext)
+            val key = Serializers.NAMESPACED_KEY.fromPrimitive(keyBytes.toString(Charsets.UTF_8), adapterContext)
 
             val valueLength = buffer.getInt()
             val value = ByteArray(valueLength)
@@ -113,10 +121,28 @@ internal class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataCo
     }
 
     companion object {
+        @JvmField
         val idKey = NamespacedKey(pluginInstance, "pylon_id")
+        @JvmField
+        val context = PylonPersistentDataAdapterContext()
 
-        private fun <T: Any?> primitiveToBytes(primitiveType: Class<T>, primitive: T): ByteArray
-            = when (primitiveType) {
+        private fun <P: Any?, C: Any?> primitiveToBytes(type: PersistentDataType<P, C>, primitive: Any): ByteArray {
+            if (type is ListPersistentDataType<*, *>) {
+                val primitiveAsList = type.primitiveType.cast(primitive)
+                val primitivesAsBytes = primitiveAsList.map {
+                    val x = type.elementType()
+                    primitiveToBytes(x, x.primitiveType.cast(it))
+                }
+                val bufferSize = primitivesAsBytes.fold(0) { acc, x -> acc + Int.SIZE_BYTES + x.size }
+                val buffer = ByteBuffer.allocate(bufferSize)
+                for (value in primitivesAsBytes) {
+                    buffer.putInt(value.size)
+                    buffer.put(value)
+                }
+                return buffer.array()
+            }
+
+            return when (type.primitiveType) {
                 Byte::class.java -> byteArrayOf(primitive as Byte)
                 Short::class.java -> ByteBuffer.allocate(Short.SIZE_BYTES).putShort(primitive as Short).array()
                 Integer::class.java -> ByteBuffer.allocate(Int.SIZE_BYTES).putInt(primitive as Int).array()
@@ -144,29 +170,43 @@ internal class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataCo
                 // This is PylonPersistentDataContainer here because when we get to deserializing PDCs, there is no way to know
                 // which implementor of PDC to serialize to. Therefore, we will only allow Pylon PDCs to be nested.
                 PersistentDataContainer::class.java -> (primitive as PylonPersistentDataContainer).serializeToBytes()
-                else -> error("Invalid primitive type '$primitiveType'")
+                else -> error("Invalid primitive type '${type.primitiveType}'")
             }
+        }
 
         // Sadly no way to 'switch' on the type T to avoid unchecked casting
         // See https://stackoverflow.com/questions/73523156/how-to-overload-function-with-different-return-types-and-the-same-parameters-in
-        @Suppress("UNCHECKED_CAST")
-        private fun <T: Any?> bytesToPrimitive(primitiveType: Class<T>, bytes: ByteArray): T
-            = when (primitiveType) {
-                Byte::class.java -> bytes[0] as T
-                Short::class.java -> ByteBuffer.wrap(bytes).getShort() as T
-                Integer::class.java -> ByteBuffer.wrap(bytes).getInt() as T
-                Long::class.java -> ByteBuffer.wrap(bytes).getLong() as T
-                Float::class.java -> ByteBuffer.wrap(bytes).getFloat() as T
-                Double::class.java -> ByteBuffer.wrap(bytes).getDouble() as T
-                String::class.java -> bytes.toString(Charsets.UTF_8) as T
-                ByteArray::class.java -> bytes as T
+        private fun <P: Any?, C: Any?> bytesToPrimitive(type: PersistentDataType<P, C>, bytes: ByteArray): P {
+            if (type is ListPersistentDataType<*, *>) {
+                val buffer = ByteBuffer.wrap(bytes)
+                val list: MutableList<Any> = mutableListOf()
+                while (buffer.hasRemaining()) {
+                    val length = buffer.getInt()
+                    val value = ByteArray(length)
+                    buffer.get(value)
+                    val primitive = bytesToPrimitive(type.elementType(), value)
+                    list.add(primitive)
+                }
+                @Suppress("UNCHECKED_CAST") // Needed to satisfy compiler but this should be safe
+                return type.primitiveType.cast(list) as P
+            }
+
+            return when (type.primitiveType) {
+                Byte::class.java -> type.primitiveType.cast(bytes[0])
+                Short::class.java -> type.primitiveType.cast(ByteBuffer.wrap(bytes).getShort())
+                Integer::class.java -> type.primitiveType.cast(ByteBuffer.wrap(bytes).getInt())
+                Long::class.java -> type.primitiveType.cast(ByteBuffer.wrap(bytes).getLong())
+                Float::class.java -> type.primitiveType.cast(ByteBuffer.wrap(bytes).getFloat())
+                Double::class.java -> type.primitiveType.cast(ByteBuffer.wrap(bytes).getDouble())
+                String::class.java -> type.primitiveType.cast(bytes.toString(Charsets.UTF_8))
+                ByteArray::class.java -> type.primitiveType.cast(bytes)
                 IntArray::class.java -> {
                     val buffer = ByteBuffer.wrap(bytes)
                     var array = intArrayOf()
                     while (buffer.hasRemaining()) {
                         array += buffer.getInt()
                     }
-                    array as T
+                    type.primitiveType.cast(array)
                 }
                 LongArray::class.java -> {
                     val buffer = ByteBuffer.wrap(bytes)
@@ -174,10 +214,11 @@ internal class PylonPersistentDataContainer(bytes: ByteArray) : PersistentDataCo
                     while (buffer.hasRemaining()) {
                         array += buffer.getLong()
                     }
-                    array as T
+                    type.primitiveType.cast(array)
                 }
-                PersistentDataContainer::class.java -> PylonPersistentDataContainer(bytes) as T
-                else -> error("Invalid primitive type '$primitiveType'")
+                PersistentDataContainer::class.java -> type.primitiveType.cast(PylonPersistentDataContainer(bytes))
+                else -> error("Invalid primitive type '${type.primitiveType}'")
             }
+        }
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/Serializers.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/Serializers.kt
@@ -3,59 +3,67 @@ package io.github.pylonmc.pylon.core.persistence
 import org.bukkit.NamespacedKey
 import org.bukkit.persistence.PersistentDataAdapterContext
 import org.bukkit.persistence.PersistentDataType
-import java.nio.ByteBuffer
 import java.util.*
 
 object Serializers {
+    @JvmField
     val BYTE = PersistentDataType.BYTE!!
+    @JvmField
     val SHORT = PersistentDataType.SHORT!!
+    @JvmField
     val INTEGER = PersistentDataType.INTEGER!!
+    @JvmField
     val LONG = PersistentDataType.LONG!!
+    @JvmField
     val FLOAT = PersistentDataType.FLOAT!!
+    @JvmField
     val DOUBLE = PersistentDataType.DOUBLE!!
+    @JvmField
     val BOOLEAN = PersistentDataType.BOOLEAN!!
+    @JvmField
     val STRING = PersistentDataType.STRING!!
+    @JvmField
     val BYTE_ARRAY = PersistentDataType.BYTE_ARRAY!!
+    @JvmField
     val INTEGER_ARRAY = PersistentDataType.INTEGER_ARRAY!!
+    @JvmField
     val LONG_ARRAY = PersistentDataType.LONG_ARRAY!!
+    @JvmField
     val TAG_CONTAINER = PersistentDataType.TAG_CONTAINER!!
+    @JvmField
     val LIST = PersistentDataType.LIST!!
+    @JvmField
     val NAMESPACED_KEY = NamespacedKeyPersistentDataType()
+    @JvmField
     val UUID = UUIDPersistentDataType()
 }
 
-class NamespacedKeyPersistentDataType : PersistentDataType<ByteArray, NamespacedKey> {
-    override fun getPrimitiveType(): Class<ByteArray>
-        = ByteArray::class.java
+class NamespacedKeyPersistentDataType : PersistentDataType<String, NamespacedKey> {
+    override fun getPrimitiveType(): Class<String>
+        = String::class.java
 
     override fun getComplexType(): Class<NamespacedKey>
         = NamespacedKey::class.java
 
-    override fun fromPrimitive(primitive: ByteArray, context: PersistentDataAdapterContext): NamespacedKey
-        = NamespacedKey.fromString(primitive.toString(Charsets.UTF_8))!!
+    override fun fromPrimitive(primitive: String, context: PersistentDataAdapterContext): NamespacedKey
+        = NamespacedKey.fromString(primitive)!!
 
-    override fun toPrimitive(complex: NamespacedKey, context: PersistentDataAdapterContext): ByteArray
-        = complex.toString().toByteArray(Charsets.UTF_8)
+    override fun toPrimitive(complex: NamespacedKey, context: PersistentDataAdapterContext): String
+        = complex.toString()
 }
 
-class UUIDPersistentDataType : PersistentDataType<ByteArray, UUID> {
-    override fun getPrimitiveType(): Class<ByteArray>
-            = ByteArray::class.java
+class UUIDPersistentDataType : PersistentDataType<LongArray, UUID> {
+    override fun getPrimitiveType(): Class<LongArray>
+            = LongArray::class.java
 
     override fun getComplexType(): Class<UUID>
             = UUID::class.java
 
-    override fun fromPrimitive(primitive: ByteArray, context: PersistentDataAdapterContext): UUID {
-        val buffer = ByteBuffer.wrap(primitive)
-        val mostSignificantBits = buffer.getLong()
-        val leastSignificantBits = buffer.getLong()
-        return UUID(mostSignificantBits , leastSignificantBits)
+    override fun fromPrimitive(primitive: LongArray, context: PersistentDataAdapterContext): UUID {
+        return UUID(primitive[0], primitive[1])
     }
 
-    override fun toPrimitive(complex: UUID, context: PersistentDataAdapterContext): ByteArray {
-        val buffer = ByteBuffer.allocate(2 * Long.SIZE_BYTES)
-        buffer.putLong(complex.mostSignificantBits)
-        buffer.putLong(complex.leastSignificantBits)
-        return buffer.array()
+    override fun toPrimitive(complex: UUID, context: PersistentDataAdapterContext): LongArray {
+        return longArrayOf(complex.mostSignificantBits, complex.leastSignificantBits)
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/Serializers.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/Serializers.kt
@@ -1,0 +1,60 @@
+package io.github.pylonmc.pylon.core.persistence
+
+import org.bukkit.NamespacedKey
+import org.bukkit.persistence.PersistentDataAdapterContext
+import org.bukkit.persistence.PersistentDataType
+import java.nio.ByteBuffer
+import java.util.*
+
+object Serializers {
+    val BYTE = PersistentDataType.BYTE!!
+    val SHORT = PersistentDataType.SHORT!!
+    val INTEGER = PersistentDataType.INTEGER!!
+    val LONG = PersistentDataType.LONG!!
+    val FLOAT = PersistentDataType.FLOAT!!
+    val DOUBLE = PersistentDataType.DOUBLE!!
+    val BOOLEAN = PersistentDataType.BOOLEAN!!
+    val STRING = PersistentDataType.STRING!!
+    val BYTE_ARRAY = PersistentDataType.BYTE_ARRAY!!
+    val INTEGER_ARRAY = PersistentDataType.INTEGER_ARRAY!!
+    val LONG_ARRAY = PersistentDataType.LONG_ARRAY!!
+    val TAG_CONTAINER = PersistentDataType.TAG_CONTAINER!!
+    val LIST = PersistentDataType.LIST!!
+    val NAMESPACED_KEY = NamespacedKeyPersistentDataType()
+}
+
+class NamespacedKeyPersistentDataType : PersistentDataType<ByteArray, NamespacedKey> {
+    override fun getPrimitiveType(): Class<ByteArray>
+        = ByteArray::class.java
+
+    override fun getComplexType(): Class<NamespacedKey>
+        = NamespacedKey::class.java
+
+    override fun fromPrimitive(primitive: ByteArray, context: PersistentDataAdapterContext): NamespacedKey
+        = NamespacedKey.fromString(primitive.toString(Charsets.UTF_8))!!
+
+    override fun toPrimitive(complex: NamespacedKey, context: PersistentDataAdapterContext): ByteArray
+        = complex.toString().toByteArray(Charsets.UTF_8)
+}
+
+class UUIDPersistentDataType : PersistentDataType<ByteArray, UUID> {
+    override fun getPrimitiveType(): Class<ByteArray>
+            = ByteArray::class.java
+
+    override fun getComplexType(): Class<UUID>
+            = UUID::class.java
+
+    override fun fromPrimitive(primitive: ByteArray, context: PersistentDataAdapterContext): UUID {
+        val buffer = ByteBuffer.wrap(primitive)
+        val mostSignificantBits = buffer.getLong()
+        val leastSignificantBits = buffer.getLong()
+        return UUID(mostSignificantBits , leastSignificantBits)
+    }
+
+    override fun toPrimitive(complex: UUID, context: PersistentDataAdapterContext): ByteArray {
+        val buffer = ByteBuffer.allocate(2 * Long.SIZE_BYTES)
+        buffer.putLong(complex.mostSignificantBits)
+        buffer.putLong(complex.leastSignificantBits)
+        return buffer.array()
+    }
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/Serializers.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/Serializers.kt
@@ -21,6 +21,7 @@ object Serializers {
     val TAG_CONTAINER = PersistentDataType.TAG_CONTAINER!!
     val LIST = PersistentDataType.LIST!!
     val NAMESPACED_KEY = NamespacedKeyPersistentDataType()
+    val UUID = UUIDPersistentDataType()
 }
 
 class NamespacedKeyPersistentDataType : PersistentDataType<ByteArray, NamespacedKey> {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/state/StateReader.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/state/StateReader.kt
@@ -1,7 +1,0 @@
-package io.github.pylonmc.pylon.core.state
-
-import org.bukkit.NamespacedKey
-
-interface StateReader {
-    val id: NamespacedKey
-}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/state/StateWriter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/state/StateWriter.kt
@@ -1,7 +1,0 @@
-package io.github.pylonmc.pylon.core.state
-
-import org.bukkit.NamespacedKey
-
-interface StateWriter {
-    val id: NamespacedKey
-}


### PR DESCRIPTION
Adds our implementation of PersistentDataContainer for use in BlockStorage.

I will add testing for this (including nested PDCs) in another PR when we have the test addon going.