### PR TITLE
Consistency-ise block and item classes

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlock.kt
@@ -6,7 +6,11 @@ import io.github.pylonmc.pylon.core.registry.PylonRegistry
 import org.bukkit.NamespacedKey
 import org.bukkit.block.Block
 
-open class PylonBlock<S: PylonBlockSchema> private constructor(val schema: S, val block: Block) {
+abstract class PylonBlock<out S: PylonBlockSchema> protected constructor(
+    val schema: S,
+    val block: Block
+) {
+
     constructor(reader: PylonDataReader, block: Block)
             : this(getSchemaOfType<S>(reader.id), block)
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/SimplePylonBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/SimplePylonBlock.kt
@@ -1,0 +1,10 @@
+package io.github.pylonmc.pylon.core.block
+
+import io.github.pylonmc.pylon.core.persistence.PylonDataReader
+import org.bukkit.block.Block
+
+class SimplePylonBlock : PylonBlock<PylonBlockSchema> {
+    constructor(schema: PylonBlockSchema, block: Block) : super(schema, block)
+
+    constructor(reader: PylonDataReader, block: Block) : super(reader, block)
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItem.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItem.kt
@@ -8,9 +8,9 @@ import org.bukkit.inventory.ItemStack
 
 abstract class PylonItem<out S: PylonItemSchema>(
     val schema: S,
-    stack: ItemStack
-) : ItemStack(stack) {
-    val id = persistentDataContainer.get(idKey, PylonSerializers.NAMESPACED_KEY)!!
+    val stack: ItemStack
+) {
+    val id = stack.persistentDataContainer.get(idKey, PylonSerializers.NAMESPACED_KEY)!!
 
     override fun equals(other: Any?): Boolean
             = id == (other as? PylonItem<*>)?.id

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItem.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItem.kt
@@ -6,11 +6,14 @@ import io.github.pylonmc.pylon.core.registry.PylonRegistry
 import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
 
-open class PylonItem(stack: ItemStack) : ItemStack(stack) {
+abstract class PylonItem<out S: PylonItemSchema>(
+    val schema: S,
+    stack: ItemStack
+) : ItemStack(stack) {
     val id = persistentDataContainer.get(idKey, PylonSerializers.NAMESPACED_KEY)!!
 
     override fun equals(other: Any?): Boolean
-            = id == (other as? PylonItem)?.id
+            = id == (other as? PylonItem<*>)?.id
 
     override fun hashCode(): Int
             = id.hashCode()
@@ -22,12 +25,12 @@ open class PylonItem(stack: ItemStack) : ItemStack(stack) {
          * Converts a regular ItemStack to a PylonItemStack
          * Returns null if the ItemStack is not a Pylon item
          */
-        fun fromStack(stack: ItemStack): PylonItem? {
+        fun fromStack(stack: ItemStack): PylonItem<*>? {
             val id = stack.persistentDataContainer.get(idKey, PylonSerializers.NAMESPACED_KEY)
                 ?: return null
-            val item = PylonRegistry.ITEMS[id]
+            val schema = PylonRegistry.ITEMS[id]
                 ?: return null
-            return item.itemClass.cast(item.loadConstructor.invoke(stack))
+            return schema.itemClass.cast(schema.loadConstructor.invoke(schema, stack))
         }
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItemSchema.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItemSchema.kt
@@ -11,7 +11,7 @@ import java.lang.invoke.MethodHandles
 
 open class PylonItemSchema(
     private val id: NamespacedKey,
-    internal val itemClass: Class<out PylonItem>,
+    internal val itemClass: Class<out PylonItem<PylonItemSchema>>,
     private val template: ItemStack,
 ) : Keyed {
     init {
@@ -24,7 +24,10 @@ open class PylonItemSchema(
         get() = template.clone()
 
     internal val loadConstructor: MethodHandle = try {
-        MethodHandles.lookup().unreflectConstructor(itemClass.getConstructor(ItemStack::class.java))
+        MethodHandles.lookup().unreflectConstructor(itemClass.getConstructor(
+            PylonItemSchema::class.java,
+            ItemStack::class.java
+        ))
     } catch (_: NoSuchMethodException) {
         throw NoSuchMethodException("Item '$key' is missing a load constructor")
     }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimplePylonItem.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimplePylonItem.kt
@@ -1,0 +1,8 @@
+package io.github.pylonmc.pylon.core.item
+
+import org.bukkit.inventory.ItemStack
+
+class SimplePylonItem(
+    schema: PylonItemSchema,
+    stack: ItemStack
+) : PylonItem<PylonItemSchema>(schema, stack)

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/gametest/PylonItemStackInterfaceTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/gametest/PylonItemStackInterfaceTest.java
@@ -18,11 +18,11 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 public class PylonItemStackInterfaceTest {
-    private static boolean handlerCalled = false;
+    private static boolean handlerCalled;
 
-    public static class OminousBlazePower extends PylonItem implements BrewingStandFuel {
-        public OminousBlazePower(@NotNull ItemStack stack) {
-            super(stack);
+    public static class OminousBlazePower extends PylonItem<PylonItemSchema> implements BrewingStandFuel {
+        public OminousBlazePower(@NotNull PylonItemSchema schema, @NotNull ItemStack stack) {
+            super(schema, stack);
         }
 
         @Override

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/generictest/PylonItemStackSimpleTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/generictest/PylonItemStackSimpleTest.java
@@ -3,6 +3,7 @@ package io.github.pylonmc.pylon.test.generictest;
 import io.github.pylonmc.pylon.core.item.ItemStackBuilder;
 import io.github.pylonmc.pylon.core.item.PylonItem;
 import io.github.pylonmc.pylon.core.item.PylonItemSchema;
+import io.github.pylonmc.pylon.core.item.SimplePylonItem;
 import io.github.pylonmc.pylon.test.GenericTest;
 import io.github.pylonmc.pylon.test.TestAddon;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -16,7 +17,7 @@ public class PylonItemStackSimpleTest implements GenericTest {
     public void run() {
         new PylonItemSchema(
                 TestAddon.key("pylon_item_stack_simple_test"),
-                PylonItem.class,
+                SimplePylonItem.class,
                 new ItemStackBuilder(Material.DIAMOND_SWORD)
                         .set(DataComponentTypes.CUSTOM_NAME, Component.text("Ominous blaze powder")
                                 .color(TextColor.color(255, 0, 0)))
@@ -27,7 +28,4 @@ public class PylonItemStackSimpleTest implements GenericTest {
                         .build()
         ).register();
     }
-
-    @Override
-    public void cleanup() {}
 }


### PR DESCRIPTION
I noticed some problems with block and item [schemas] while testing. PylonBlock and PylonItem are now abstract and have corresponding simple implementations. PylonItem is now parameterized by schema and also now stores a schema when loaded, this was a big oversight in my initial PR