### PR TITLE
Lambda func for simpleitemschema itemstack

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/ItemStackBuilder.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/ItemStackBuilder.kt
@@ -10,6 +10,8 @@ import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.Material
 import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.Damageable
+import org.bukkit.util.Consumer
 import java.util.EnumSet
 
 
@@ -28,6 +30,10 @@ open class ItemStackBuilder(private val stack: ItemStack) {
 
     fun <T : Any> set(type: DataComponentType.Valued<T>, value: T) = apply {
         stack.setData(type, value)
+    }
+
+    fun <T: Any> set(type: MetaComponentType<T>, value: T) = apply {
+        stack.itemMeta = type.ModifyMeta(stack.itemMeta, value)
     }
 
     fun set(type: DataComponentType.NonValued) = apply {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/MetaComponentTypes.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/MetaComponentTypes.kt
@@ -1,0 +1,21 @@
+package io.github.pylonmc.pylon.core.item
+
+import org.bukkit.inventory.meta.Damageable
+import org.bukkit.inventory.meta.ItemMeta
+import java.lang.reflect.Method
+
+open class MetaComponentType<T>(metaClass: Class<out ItemMeta>, methodToRun: Method) {
+    private val metaSpecification: Class<out ItemMeta> = metaClass
+    private val metaModificationMethod: Method = methodToRun
+    fun ModifyMeta(itemMeta: ItemMeta, value: T): ItemMeta {
+        //(itemMeta as metaSpecification)
+        metaModificationMethod.invoke(metaSpecification.cast(itemMeta), value);
+        return itemMeta;
+    }
+}
+
+public final class MetaComponentTypes {
+    companion object {
+        public final val DURABILITY: MetaComponentType<Int> = MetaComponentType<Int>(Damageable::class.java, Damageable::class.java.getMethod("setMaxDamage", Integer::class.java))
+    }
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
@@ -6,18 +6,16 @@ import io.github.pylonmc.pylon.core.registry.PylonRegistry
 import org.bukkit.Keyed
 import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
+import java.util.concurrent.Callable
 import javax.xml.stream.events.Namespace
 
 open class SimpleItemSchema<R : Keyed> @JvmOverloads constructor(
     id: NamespacedKey,
-    template: ItemStack,
+    template: Callable<ItemStack>,
     private val recipeType: RecipeType<R>,
     private val recipe: (ItemStack) -> R,
     private val block: PylonBlockSchema? = null
-) : PylonItemSchema(id, SimplePylonItem::class.java, template) {
-    constructor(id: NamespacedKey, template: () -> ItemStack, recipeType: RecipeType<R>,
-                recipe: (ItemStack) -> R, block: PylonBlockSchema? = null)
-            : this(id, template.invoke(), recipeType, recipe, block)
+) : PylonItemSchema(id, SimplePylonItem::class.java, template.call()) {
 
     private var recipeKey: NamespacedKey? = null
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
@@ -6,6 +6,7 @@ import io.github.pylonmc.pylon.core.registry.PylonRegistry
 import org.bukkit.Keyed
 import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
+import javax.xml.stream.events.Namespace
 
 open class SimpleItemSchema<R : Keyed> @JvmOverloads constructor(
     id: NamespacedKey,
@@ -14,6 +15,9 @@ open class SimpleItemSchema<R : Keyed> @JvmOverloads constructor(
     private val recipe: (ItemStack) -> R,
     private val block: PylonBlockSchema? = null
 ) : PylonItemSchema(id, SimplePylonItem::class.java, template) {
+    constructor(id: NamespacedKey, template: () -> ItemStack, recipeType: RecipeType<R>,
+                recipe: (ItemStack) -> R, block: PylonBlockSchema? = null)
+            : this(id, template.invoke(), recipeType, recipe, block)
 
     private var recipeKey: NamespacedKey? = null
 

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/PylonTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/PylonTest.java
@@ -6,6 +6,7 @@ import io.github.pylonmc.pylon.test.base.TestResult;
 import io.github.pylonmc.pylon.test.test.block.*;
 import io.github.pylonmc.pylon.test.test.item.PylonItemStackInterfaceTest;
 import io.github.pylonmc.pylon.test.test.item.PylonItemStackSimpleTest;
+import io.github.pylonmc.pylon.test.test.item.SimpleItemSchemaTest;
 import io.github.pylonmc.pylon.test.test.misc.GametestTest;
 import io.github.pylonmc.pylon.test.test.recipe.CraftingTest;
 import io.github.pylonmc.pylon.test.test.recipe.FurnaceTest;
@@ -43,6 +44,7 @@ public class PylonTest extends JavaPlugin implements PylonAddon {
 
         tests.add(new PylonItemStackSimpleTest());
         tests.add(new PylonItemStackInterfaceTest());
+        tests.add(new SimpleItemSchemaTest());
 
         tests.add(new GametestTest());
 

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/item/SimpleItemSchemaTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/item/SimpleItemSchemaTest.java
@@ -28,7 +28,7 @@ public class SimpleItemSchemaTest extends SyncTest {
         PylonItemSchema itemwithmeta = new SimpleItemSchema<>(
                 PylonTest.key("simple_item_schema_3"),
                 () -> {
-                    ItemStack item = new ItemStackBuilder(Material.ACACIA_BUTTON)
+                    ItemStack item = new ItemStackBuilder(Material.DIAMOND_SWORD)
                             .name("A cool item")
                             .lore("Something cool")
                             .set(DataComponentTypes.RARITY, ItemRarity.RARE)

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/item/SimpleItemSchemaTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/item/SimpleItemSchemaTest.java
@@ -46,8 +46,30 @@ public class SimpleItemSchemaTest extends SyncTest {
                 }
         );
 
-        PylonItemSchema itemwithmeta = new SimpleItemSchema<>(
+        PylonItemSchema duplicateoldformat = new SimpleItemSchema<>(
                 PylonTest.key("simple_item_schema_2"),
+                () -> new ItemStackBuilder(Material.ACACIA_BUTTON)
+                        .name("A cool item")
+                        .lore("Something cool")
+                        .set(DataComponentTypes.RARITY, ItemRarity.RARE)
+                        .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
+                        .build(),
+                RecipeTypes.VANILLA_CRAFTING,
+                testitem -> {
+                    ShapedRecipe recipe = new ShapedRecipe(PylonTest.key("simple_item_schema_1"), testitem);
+                    recipe.shape(
+                            "SSS",
+                            "SSS",
+                            "SSS"
+                    );
+                    recipe.setIngredient('S', Material.STICK);
+                    recipe.setCategory(CraftingBookCategory.MISC);
+                    return recipe;
+                }
+        );
+
+        PylonItemSchema itemwithmeta = new SimpleItemSchema<>(
+                PylonTest.key("simple_item_schema_3"),
                 () -> {
                     ItemStack item = new ItemStackBuilder(Material.ACACIA_BUTTON)
                             .name("A cool item")
@@ -74,6 +96,7 @@ public class SimpleItemSchemaTest extends SyncTest {
                 }
         );
 
+        assertThat(oldformat.getItemStack()).isEqualTo(duplicateoldformat.getItemStack());
         assertThat(oldformat.getItemStack()).isNotEqualTo(itemwithmeta.getItemStack());
     }
 }

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/item/SimpleItemSchemaTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/item/SimpleItemSchemaTest.java
@@ -8,9 +8,15 @@ import io.github.pylonmc.pylon.test.PylonTest;
 import io.github.pylonmc.pylon.test.base.SyncTest;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import org.bukkit.Material;
+import org.bukkit.inventory.CraftingRecipe;
 import org.bukkit.inventory.ItemRarity;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.recipe.CraftingBookCategory;
+
+import java.util.concurrent.Callable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,9 +24,9 @@ public class SimpleItemSchemaTest extends SyncTest {
 
     @Override
     public void test() {
-        PylonItemSchema primaryconstructor = new SimpleItemSchema<>(
+        PylonItemSchema oldformat = new SimpleItemSchema<>(
                 PylonTest.key("simple_item_schema_1"),
-                new ItemStackBuilder(Material.ACACIA_BUTTON)
+                () -> new ItemStackBuilder(Material.ACACIA_BUTTON)
                         .name("A cool item")
                         .lore("Something cool")
                         .set(DataComponentTypes.RARITY, ItemRarity.RARE)
@@ -40,14 +46,20 @@ public class SimpleItemSchemaTest extends SyncTest {
                 }
         );
 
-        PylonItemSchema secondaryconstructor = new SimpleItemSchema<>(
+        PylonItemSchema itemwithmeta = new SimpleItemSchema<>(
                 PylonTest.key("simple_item_schema_2"),
-                new ItemStackBuilder(Material.ACACIA_BUTTON)
-                        .name("A cool item")
-                        .lore("Something cool")
-                        .set(DataComponentTypes.RARITY, ItemRarity.RARE)
-                        .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
-                        .build(),
+                () -> {
+                    ItemStack item = new ItemStackBuilder(Material.ACACIA_BUTTON)
+                            .name("A cool item")
+                            .lore("Something cool")
+                            .set(DataComponentTypes.RARITY, ItemRarity.RARE)
+                            .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
+                            .build();
+                    Damageable meta = (Damageable) item.getItemMeta();
+                    meta.setMaxDamage(200);
+                    item.setItemMeta(meta);
+                    return item;
+                },
                 RecipeTypes.VANILLA_CRAFTING,
                 testitem -> {
                     ShapedRecipe recipe = new ShapedRecipe(PylonTest.key("simple_item_schema_2"), testitem);
@@ -62,6 +74,6 @@ public class SimpleItemSchemaTest extends SyncTest {
                 }
         );
 
-        assertThat(primaryconstructor.getItemStack()).isEqualTo(secondaryconstructor.getItemStack());
+        assertThat(oldformat.getItemStack()).isNotEqualTo(itemwithmeta.getItemStack());
     }
 }

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/item/SimpleItemSchemaTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/item/SimpleItemSchemaTest.java
@@ -1,0 +1,67 @@
+package io.github.pylonmc.pylon.test.test.item;
+
+import io.github.pylonmc.pylon.core.item.ItemStackBuilder;
+import io.github.pylonmc.pylon.core.item.PylonItemSchema;
+import io.github.pylonmc.pylon.core.item.SimpleItemSchema;
+import io.github.pylonmc.pylon.core.recipe.RecipeTypes;
+import io.github.pylonmc.pylon.test.PylonTest;
+import io.github.pylonmc.pylon.test.base.SyncTest;
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemRarity;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.recipe.CraftingBookCategory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleItemSchemaTest extends SyncTest {
+
+    @Override
+    public void test() {
+        PylonItemSchema primaryconstructor = new SimpleItemSchema<>(
+                PylonTest.key("simple_item_schema_1"),
+                new ItemStackBuilder(Material.ACACIA_BUTTON)
+                        .name("A cool item")
+                        .lore("Something cool")
+                        .set(DataComponentTypes.RARITY, ItemRarity.RARE)
+                        .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
+                        .build(),
+                RecipeTypes.VANILLA_CRAFTING,
+                testitem -> {
+                    ShapedRecipe recipe = new ShapedRecipe(PylonTest.key("simple_item_schema_1"), testitem);
+                    recipe.shape(
+                            "SSS",
+                            "SSS",
+                            "SSS"
+                    );
+                    recipe.setIngredient('S', Material.STICK);
+                    recipe.setCategory(CraftingBookCategory.MISC);
+                    return recipe;
+                }
+        );
+
+        PylonItemSchema secondaryconstructor = new SimpleItemSchema<>(
+                PylonTest.key("simple_item_schema_2"),
+                new ItemStackBuilder(Material.ACACIA_BUTTON)
+                        .name("A cool item")
+                        .lore("Something cool")
+                        .set(DataComponentTypes.RARITY, ItemRarity.RARE)
+                        .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
+                        .build(),
+                RecipeTypes.VANILLA_CRAFTING,
+                testitem -> {
+                    ShapedRecipe recipe = new ShapedRecipe(PylonTest.key("simple_item_schema_2"), testitem);
+                    recipe.shape(
+                            "SSS",
+                            "SSS",
+                            "SSS"
+                    );
+                    recipe.setIngredient('S', Material.STICK);
+                    recipe.setCategory(CraftingBookCategory.MISC);
+                    return recipe;
+                }
+        );
+
+        assertThat(primaryconstructor.getItemStack()).isEqualTo(secondaryconstructor.getItemStack());
+    }
+}

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/item/SimpleItemSchemaTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/item/SimpleItemSchemaTest.java
@@ -16,6 +16,7 @@ import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.recipe.CraftingBookCategory;
 
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,50 +25,6 @@ public class SimpleItemSchemaTest extends SyncTest {
 
     @Override
     public void test() {
-        PylonItemSchema oldformat = new SimpleItemSchema<>(
-                PylonTest.key("simple_item_schema_1"),
-                () -> new ItemStackBuilder(Material.ACACIA_BUTTON)
-                        .name("A cool item")
-                        .lore("Something cool")
-                        .set(DataComponentTypes.RARITY, ItemRarity.RARE)
-                        .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
-                        .build(),
-                RecipeTypes.VANILLA_CRAFTING,
-                testitem -> {
-                    ShapedRecipe recipe = new ShapedRecipe(PylonTest.key("simple_item_schema_1"), testitem);
-                    recipe.shape(
-                            "SSS",
-                            "SSS",
-                            "SSS"
-                    );
-                    recipe.setIngredient('S', Material.STICK);
-                    recipe.setCategory(CraftingBookCategory.MISC);
-                    return recipe;
-                }
-        );
-
-        PylonItemSchema duplicateoldformat = new SimpleItemSchema<>(
-                PylonTest.key("simple_item_schema_2"),
-                () -> new ItemStackBuilder(Material.ACACIA_BUTTON)
-                        .name("A cool item")
-                        .lore("Something cool")
-                        .set(DataComponentTypes.RARITY, ItemRarity.RARE)
-                        .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
-                        .build(),
-                RecipeTypes.VANILLA_CRAFTING,
-                testitem -> {
-                    ShapedRecipe recipe = new ShapedRecipe(PylonTest.key("simple_item_schema_1"), testitem);
-                    recipe.shape(
-                            "SSS",
-                            "SSS",
-                            "SSS"
-                    );
-                    recipe.setIngredient('S', Material.STICK);
-                    recipe.setCategory(CraftingBookCategory.MISC);
-                    return recipe;
-                }
-        );
-
         PylonItemSchema itemwithmeta = new SimpleItemSchema<>(
                 PylonTest.key("simple_item_schema_3"),
                 () -> {
@@ -95,8 +52,6 @@ public class SimpleItemSchemaTest extends SyncTest {
                     return recipe;
                 }
         );
-
-        assertThat(oldformat.getItemStack()).isEqualTo(duplicateoldformat.getItemStack());
-        assertThat(oldformat.getItemStack()).isNotEqualTo(itemwithmeta.getItemStack());
+        assertThat(((Damageable)itemwithmeta.getItemStack().getItemMeta()).getMaxDamage()).isEqualTo(200);
     }
 }


### PR DESCRIPTION
This is a breaking change for the current base PRs, so maybe wait to merge this until after those are in and I will make a base PR to deal with the breaking. The point of this PR is to let you use a lambda func to define the ItemStack template for a BasicItemSchema, allowing you to set item metadata, as in this example: https://gist.github.com/OhmV-IR/563c1fb92b1b9e92ec982a9781aff37e (gh formatting completely cooks the readability if I put it here, sorry)


With the old constructor, you couldn't set the max durability of the item because there wasn't a method to do it in the ItemStackBuilder since its not on every item, just those that have the damageable meta. Have added test for this in SimpleItemSchemaTest.java