### PR TITLE
Fix recipe matching

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/RecipeTypes.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/RecipeTypes.kt
@@ -55,8 +55,10 @@ private object CraftingRecipeType : VanillaRecipe<CraftingRecipe>("crafting") {
     @EventHandler(priority = EventPriority.LOWEST)
     private fun onPreCraft(e: PrepareItemCraftEvent) {
         val recipe = e.recipe ?: return
+        // All recipe types but MerchantRecipe implement Keyed
+        if(recipe !is Keyed) return
         val inventory = e.inventory
-        if (recipes.all { it != recipe } && inventory.any { it.isPylonAndIsNot<VanillaCraftingItem>() }) {
+        if (recipes.all { it.key != recipe.key } && inventory.any { it.isPylonAndIsNot<VanillaCraftingItem>() }){
             // Prevent the erroneous crafting of vanilla items with Pylon ingredients
             inventory.result = null
         }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/RecipeTypes.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/RecipeTypes.kt
@@ -58,7 +58,7 @@ private object CraftingRecipeType : VanillaRecipe<CraftingRecipe>("crafting") {
         // All recipe types but MerchantRecipe implement Keyed
         if(recipe !is Keyed) return
         val inventory = e.inventory
-        if (recipes.all { it.key != recipe.key } && inventory.any { it.isPylonAndIsNot<VanillaCraftingItem>() }){
+        if (recipes.all { it.key != recipe.key } && inventory.any { it.isPylonAndIsNot<VanillaCraftingItem>() }) {
             // Prevent the erroneous crafting of vanilla items with Pylon ingredients
             inventory.result = null
         }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/RecipeTypes.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/RecipeTypes.kt
@@ -54,7 +54,7 @@ private object CraftingRecipeType : VanillaRecipe<CraftingRecipe>("crafting") {
 
     @EventHandler(priority = EventPriority.LOWEST)
     private fun onPreCraft(e: PrepareItemCraftEvent) {
-        val recipe = e.recipe ?: return
+        val recipe = e.recipe
         // All recipe types but MerchantRecipe implement Keyed
         if(recipe !is Keyed) return
         val inventory = e.inventory
@@ -86,7 +86,7 @@ private object SmithingRecipeType : VanillaRecipe<SmithingRecipe>("smithing") {
     private fun onSmith(e: PrepareSmithingEvent) {
         val inv = e.inventory
         val recipe = inv.recipe
-        if(recipe == null || recipe !is Keyed) return
+        if(recipe !is Keyed) return
         if (
             recipes.all { it.key != recipe.key } &&
             (

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/RecipeTypes.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/RecipeTypes.kt
@@ -85,8 +85,10 @@ private object SmithingRecipeType : VanillaRecipe<SmithingRecipe>("smithing") {
     @EventHandler(priority = EventPriority.LOWEST)
     private fun onSmith(e: PrepareSmithingEvent) {
         val inv = e.inventory
+        val recipe = inv.recipe
+        if(recipe == null || recipe !is Keyed) return
         if (
-            recipes.all { it != inv.recipe } &&
+            recipes.all { it.key != recipe.key } &&
             (
                     inv.inputMineral.isPylonAndIsNot<VanillaSmithingMaterial>() ||
                     inv.inputTemplate.isPylonAndIsNot<VanillaSmithingTemplate>()


### PR DESCRIPTION
As shown on discord, fixes the PylonItem -> VanillaItem crafting protection by comparing keys instead of Recipe objects, still don't know why the matching wasn't working properly on it though. 