### PR TITLE
recipe vararg in SimpleItemSchema

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
@@ -16,21 +16,20 @@ open class SimpleItemSchema<R : Keyed>
         vararg val recipes: (ItemStack) -> R,
     ) : PylonItemSchema(id, SimplePylonItem::class.java, template) {
 
-    private var recipeKey: NamespacedKey? = null
+    private var recipeKeys: MutableList<NamespacedKey> = mutableListOf()
 
     override fun onRegister(registry: PylonRegistry<*>) {
         super.onRegister(registry)
         for(recipe in recipes){
             val recipeInstance = recipe(itemStack)
-            recipeKey = recipeInstance.key
+            recipeKeys.add(recipeInstance.key)
             recipeType.addRecipe(recipeInstance)
         }
     }
 
     override fun onUnregister(registry: PylonRegistry<*>) {
-        if (recipeKey != null) {
-            recipeType.removeRecipe(recipeKey!!)
-            recipeKey = null
+        for(key in recipeKeys){
+            recipeType.removeRecipe(key)
         }
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
@@ -28,7 +28,7 @@ open class SimpleItemSchema<R : Keyed>
     }
 
     override fun onUnregister(registry: PylonRegistry<*>) {
-        for(key in recipeKeys){
+        for (key in recipeKeys) {
             recipeType.removeRecipe(key)
         }
     }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
@@ -20,7 +20,7 @@ open class SimpleItemSchema<R : Keyed>
 
     override fun onRegister(registry: PylonRegistry<*>) {
         super.onRegister(registry)
-        for(recipe in recipes){
+        for (recipe in recipes) {
             val recipeInstance = recipe(itemStack)
             recipeKeys.add(recipeInstance.key)
             recipeType.addRecipe(recipeInstance)

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
@@ -16,7 +16,7 @@ open class SimpleItemSchema<R : Keyed>
         vararg val recipes: (ItemStack) -> R,
     ) : PylonItemSchema(id, SimplePylonItem::class.java, template) {
 
-    private var recipeKeys: MutableList<NamespacedKey> = mutableListOf()
+    private var recipeKeys = mutableListOf<NamespacedKey>()
 
     override fun onRegister(registry: PylonRegistry<*>) {
         super.onRegister(registry)

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/SimpleItemSchema.kt
@@ -7,20 +7,24 @@ import org.bukkit.Keyed
 import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
 
-open class SimpleItemSchema<R : Keyed>(
-    id: NamespacedKey,
-    template: ItemStack,
-    private val recipeType: RecipeType<R>,
-    private val recipe: (ItemStack) -> R,
-) : PylonItemSchema(id, SimplePylonItem::class.java, template) {
+open class SimpleItemSchema<R : Keyed>
+    @SafeVarargs
+    constructor(
+        id: NamespacedKey,
+        template: ItemStack,
+        private val recipeType: RecipeType<R>,
+        vararg val recipes: (ItemStack) -> R,
+    ) : PylonItemSchema(id, SimplePylonItem::class.java, template) {
 
     private var recipeKey: NamespacedKey? = null
 
     override fun onRegister(registry: PylonRegistry<*>) {
         super.onRegister(registry)
-        val recipeInstance = recipe(itemStack)
-        recipeKey = recipeInstance.key
-        recipeType.addRecipe(recipeInstance)
+        for(recipe in recipes){
+            val recipeInstance = recipe(itemStack)
+            recipeKey = recipeInstance.key
+            recipeType.addRecipe(recipeInstance)
+        }
     }
 
     override fun onUnregister(registry: PylonRegistry<*>) {


### PR DESCRIPTION
Non-breaking, just allows for multiple recipes to be made with SimpleItemSchema. Nothing on base needs this, just thought we probably would at somepoint. Same syntax as before in regard to how the recipes are defined