### PR TITLE
Add entities

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/PylonCore.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/PylonCore.kt
@@ -9,6 +9,7 @@ import io.github.pylonmc.pylon.core.block.BlockListener
 import io.github.pylonmc.pylon.core.block.MultiblockCache
 import io.github.pylonmc.pylon.core.block.TickManager
 import io.github.pylonmc.pylon.core.debug.DebugWaxedWeatheredCutCopperStairs
+import io.github.pylonmc.pylon.core.entity.EntityStorage
 import io.github.pylonmc.pylon.core.item.PylonItemListener
 import io.github.pylonmc.pylon.core.mobdrop.MobDropListener
 import io.github.pylonmc.pylon.core.persistence.blockstorage.BlockStorage
@@ -33,6 +34,7 @@ class PylonCore : JavaPlugin(), PylonAddon {
         Bukkit.getPluginManager().registerEvents(TickManager, this)
         Bukkit.getPluginManager().registerEvents(PylonAddonListener, this)
         Bukkit.getPluginManager().registerEvents(MultiblockCache, this)
+        Bukkit.getPluginManager().registerEvents(EntityStorage, this)
 
         Bukkit.getScheduler().runTaskTimer(
             this,

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/PylonCore.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/PylonCore.kt
@@ -59,6 +59,7 @@ class PylonCore : JavaPlugin(), PylonAddon {
 
     override fun onDisable() {
         BlockStorage.cleanupEverything()
+        EntityStorage.cleanupEverything()
 
         instance = null
     }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/addon/PylonAddonListener.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/addon/PylonAddonListener.kt
@@ -1,5 +1,6 @@
 package io.github.pylonmc.pylon.core.addon
 
+import io.github.pylonmc.pylon.core.entity.EntityStorage
 import io.github.pylonmc.pylon.core.persistence.blockstorage.BlockStorage
 import io.github.pylonmc.pylon.core.registry.PylonRegistry
 import org.bukkit.event.EventHandler
@@ -11,11 +12,15 @@ internal object PylonAddonListener : Listener {
     private fun onPluginDisable(event: PluginDisableEvent) {
         val plugin = event.plugin
         if (plugin is PylonAddon) {
-            PylonRegistry.ADDONS.unregister(plugin)
-            PylonRegistry.GAMETESTS.unregisterAllFromAddon(plugin)
-            PylonRegistry.ITEMS.unregisterAllFromAddon(plugin)
             BlockStorage.cleanup(plugin)
             PylonRegistry.BLOCKS.unregisterAllFromAddon(plugin)
+            EntityStorage.cleanup(plugin)
+            PylonRegistry.ENTITIES.unregisterAllFromAddon(plugin)
+            PylonRegistry.GAMETESTS.unregisterAllFromAddon(plugin)
+            PylonRegistry.ITEMS.unregisterAllFromAddon(plugin)
+            PylonRegistry.RECIPE_TYPES.unregisterAllFromAddon(plugin)
+            PylonRegistry.MOB_DROPS.unregisterAllFromAddon(plugin)
+            PylonRegistry.ADDONS.unregister(plugin)
         }
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/debug/DebugWaxedWeatheredCutCopperStairs.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/debug/DebugWaxedWeatheredCutCopperStairs.kt
@@ -36,7 +36,11 @@ object DebugWaxedWeatheredCutCopperStairs : PylonItemSchema(
         PylonItem<DebugWaxedWeatheredCutCopperStairs>(schema, item), BlockInteractor, EntityInteractor {
         override fun onUsedToClickBlock(event: PlayerInteractEvent) {
             val block = event.clickedBlock ?: return
-            val pylonBlock = BlockStorage.get(block) ?: return
+            val pylonBlock = BlockStorage.get(block)
+            if (pylonBlock == null) {
+                event.player.sendMessage(NamedTextColor.RED + "This is not a Pylon block")
+                return
+            }
             val player = event.player
             player.sendMessage(NamedTextColor.GOLD + "Pylon block key: ${pylonBlock.schema.key}")
             player.sendMessage(
@@ -56,7 +60,11 @@ object DebugWaxedWeatheredCutCopperStairs : PylonItemSchema(
         }
 
         override fun onUsedToRightClickEntity(event: PlayerInteractEntityEvent) {
-            val pylonEntity = EntityStorage.get(event.rightClicked) ?: return
+            val pylonEntity = EntityStorage.get(event.rightClicked)
+            if (pylonEntity == null) {
+                event.player.sendMessage(NamedTextColor.RED + "This is not a Pylon entity")
+                return
+            }
             event.player.sendMessage(NamedTextColor.GOLD + "Pylon entity key: ${pylonEntity.schema.key}")
             event.player.sendMessage(
                 MiniMessage.miniMessage().deserialize(

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/debug/DebugWaxedWeatheredCutCopperStairs.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/debug/DebugWaxedWeatheredCutCopperStairs.kt
@@ -57,7 +57,7 @@ object DebugWaxedWeatheredCutCopperStairs : PylonItemSchema(
 
         override fun onUsedToRightClickEntity(event: PlayerInteractEntityEvent) {
             val pylonEntity = EntityStorage.get(event.rightClicked) ?: return
-            event.player.sendMessage(NamedTextColor.GOLD + "Pylon block key: ${pylonEntity.schema.key}")
+            event.player.sendMessage(NamedTextColor.GOLD + "Pylon entity key: ${pylonEntity.schema.key}")
             event.player.sendMessage(
                 MiniMessage.miniMessage().deserialize(
                     when (pylonEntity) {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/debug/DebugWaxedWeatheredCutCopperStairs.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/debug/DebugWaxedWeatheredCutCopperStairs.kt
@@ -1,12 +1,14 @@
 package io.github.pylonmc.pylon.core.debug
 
 import io.github.pylonmc.pylon.core.block.TickManager
+import io.github.pylonmc.pylon.core.entity.EntityStorage
 import io.github.pylonmc.pylon.core.block.base.PylonTickingBlock
 import io.github.pylonmc.pylon.core.item.ItemStackBuilder
 import io.github.pylonmc.pylon.core.item.LoreBuilder
 import io.github.pylonmc.pylon.core.item.PylonItem
 import io.github.pylonmc.pylon.core.item.PylonItemSchema
 import io.github.pylonmc.pylon.core.item.base.BlockInteractor
+import io.github.pylonmc.pylon.core.item.base.EntityInteractor
 import io.github.pylonmc.pylon.core.persistence.blockstorage.BlockStorage
 import io.github.pylonmc.pylon.core.util.plus
 import io.github.pylonmc.pylon.core.util.pylonKey
@@ -14,6 +16,7 @@ import io.papermc.paper.datacomponent.DataComponentTypes
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.Material
+import org.bukkit.event.player.PlayerInteractEntityEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.inventory.ItemStack
 
@@ -23,13 +26,14 @@ object DebugWaxedWeatheredCutCopperStairs : PylonItemSchema(
     ItemInstance::class.java,
     ItemStackBuilder(Material.WAXED_WEATHERED_CUT_COPPER_STAIRS)
             .name("<red>Debug Waxed Weathered Cut Copper Stairs")
-            .lore(LoreBuilder().instruction("Right click").text(" a block to view its Pylon block data"))
+            .lore(LoreBuilder().instruction("Right click").text(" a block to view its Pylon data"))
+            .lore(LoreBuilder().instruction("Right click").text(" an entity to view its Pylon data"))
             .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
             .build()
 ) {
 
     class ItemInstance(schema: DebugWaxedWeatheredCutCopperStairs, item: ItemStack) :
-        PylonItem<DebugWaxedWeatheredCutCopperStairs>(schema, item), BlockInteractor {
+        PylonItem<DebugWaxedWeatheredCutCopperStairs>(schema, item), BlockInteractor, EntityInteractor {
         override fun onUsedToClickBlock(event: PlayerInteractEvent) {
             val block = event.clickedBlock ?: return
             val pylonBlock = BlockStorage.get(block) ?: return
@@ -49,6 +53,26 @@ object DebugWaxedWeatheredCutCopperStairs : PylonItemSchema(
                 )
             )
             pylonBlock.write(PrintingPDC(player))
+        }
+
+        override fun onUsedToRightClickEntity(event: PlayerInteractEntityEvent) {
+            val pylonEntity = EntityStorage.get(event.rightClicked) ?: return
+            event.player.sendMessage(NamedTextColor.GOLD + "Pylon block key: ${pylonEntity.schema.key}")
+            event.player.sendMessage(
+                MiniMessage.miniMessage().deserialize(
+                    when (pylonEntity) {
+                        // TODO implement this once entities can tick
+                        is PylonTickingBlock -> if (false) {
+                            "<gold>Ticking: <green>Yes"
+                        } else {
+                            "<gold>Ticking: <red>Ticker has errored"
+                        }
+
+                        else -> "<gold>Ticking: <red>No"
+                    }
+                )
+            )
+            pylonEntity.entity.persistentDataContainer.copyTo(PrintingPDC(event.player), true)
         }
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/debug/DebugWaxedWeatheredCutCopperStairs.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/debug/DebugWaxedWeatheredCutCopperStairs.kt
@@ -26,8 +26,7 @@ object DebugWaxedWeatheredCutCopperStairs : PylonItemSchema(
     ItemInstance::class.java,
     ItemStackBuilder(Material.WAXED_WEATHERED_CUT_COPPER_STAIRS)
             .name("<red>Debug Waxed Weathered Cut Copper Stairs")
-            .lore(LoreBuilder().instruction("Right click").text(" a block to view its Pylon data"))
-            .lore(LoreBuilder().instruction("Right click").text(" an entity to view its Pylon data"))
+            .lore(LoreBuilder().instructionLine("Right click", "a block or entity to view its Pylon data"))
             .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
             .build()
 ) {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
@@ -1,0 +1,103 @@
+package io.github.pylonmc.pylon.core.entity
+
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent
+import io.github.pylonmc.pylon.core.pluginInstance
+import org.bukkit.Bukkit
+import org.bukkit.NamespacedKey
+import org.bukkit.entity.Entity
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.world.EntitiesLoadEvent
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantReadWriteLock
+
+
+object EntityStorage : Listener {
+
+    private const val AUTOSAVE_INTERVAL_TICKS = 60 * 20L
+
+    val entities: MutableMap<UUID, PylonEntity<*, *>> = ConcurrentHashMap()
+    val entitiesByType: MutableMap<NamespacedKey, MutableSet<PylonEntity<*, *>>> = ConcurrentHashMap()
+
+    // Access to blocks, blocksByChunk, blocksById fields must be synchronized
+    // to prevent them briefly going out of sync
+    private val blockLock = ReentrantReadWriteLock()
+
+    // TODO implement this properly and actually run it
+    internal fun startAutosaveTask() {
+        Bukkit.getScheduler().runTaskTimer(pluginInstance, Runnable {
+            // TODO this saves all entities at once, potentially leading to large pauses
+            for (entity in entities.values) {
+                entity.write()
+            }
+        }, AUTOSAVE_INTERVAL_TICKS, AUTOSAVE_INTERVAL_TICKS)
+    }
+
+    @JvmStatic
+    fun get(uuid: UUID): PylonEntity<*, *>?
+        = lockBlockRead { entities[uuid] }
+
+    @JvmStatic
+    fun get(entity: Entity): PylonEntity<*, *>?
+        = lockBlockRead { entities[entity.uniqueId] }
+
+    @JvmStatic
+    fun <T> getAs(clazz: Class<T>, uuid: UUID): T? {
+        val entity = get(uuid) ?: return null
+        return clazz.cast(entity)
+    }
+
+    @JvmStatic
+    fun <T> getAs(clazz: Class<T>, entity: Entity): T?
+        = getAs(clazz, entity.uniqueId)
+
+    inline fun <reified T> getAs(uuid: UUID): T?
+        = getAs(T::class.java, uuid)
+
+    inline fun <reified T> getAs(entity: Entity): T?
+        = getAs(T::class.java, entity)
+
+    @EventHandler
+    private fun onEntityLoad(event: EntitiesLoadEvent) {
+        for (entity in event.entities) {
+            PylonEntity.deserialize(entity)?.let { pylonEntity -> lockBlockWrite {
+                entities[entity.uniqueId] = pylonEntity
+                entitiesByType.getOrPut(pylonEntity.schema.key) { mutableSetOf() }.add(pylonEntity)
+            }}
+        }
+    }
+
+    // This currently does not differentiate between unloaded and dead entities because the API
+    // is broken (lol), hence the lack of an entity death listener
+    @EventHandler
+    private fun onEntityUnload(event: EntityRemoveFromWorldEvent) {
+        val pylonEntity = get(event.getEntity().uniqueId) ?: return
+        pylonEntity.write()
+        lockBlockWrite {
+            entities.remove(pylonEntity.entity.uniqueId)
+            entitiesByType[pylonEntity.schema.key]!!.remove(pylonEntity)
+            if (entitiesByType[pylonEntity.schema.key]!!.isEmpty()) {
+                entitiesByType.remove(pylonEntity.schema.key)
+            }
+        }
+    }
+
+    private inline fun <T> lockBlockRead(block: () -> T): T {
+        blockLock.readLock().lock()
+        try {
+            return block()
+        } finally {
+            blockLock.readLock().unlock()
+        }
+    }
+
+    private inline fun <T> lockBlockWrite(block: () -> T): T {
+        blockLock.writeLock().lock()
+        try {
+            return block()
+        } finally {
+            blockLock.writeLock().unlock()
+        }
+    }
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
@@ -46,7 +46,7 @@ object EntityStorage : Listener {
 
     @JvmStatic
     fun get(entity: Entity): PylonEntity<*, *>?
-        = lockEntityRead { entities[entity.uniqueId] }
+        = get(entity.uniqueId)
 
     @JvmStatic
     fun <T> getAs(clazz: Class<T>, uuid: UUID): T? {
@@ -79,7 +79,7 @@ object EntityStorage : Listener {
 
     @JvmStatic
     fun isPylonEntity(entity: Entity): Boolean
-            = get(entity) != null
+        = get(entity) != null
 
     @JvmStatic
     fun add(entity: PylonEntity<*, *>) = lockEntityWrite {
@@ -101,7 +101,7 @@ object EntityStorage : Listener {
     @EventHandler
     private fun onEntityUnload(event: EntityRemoveFromWorldEvent) {
         val pylonEntity = get(event.getEntity().uniqueId) ?: return
-        pylonEntity.write()
+        PylonEntity.serialize(pylonEntity)
         lockEntityWrite {
             entities.remove(pylonEntity.entity.uniqueId)
             entitiesById[pylonEntity.schema.key]!!.remove(pylonEntity)
@@ -115,7 +115,7 @@ object EntityStorage : Listener {
     internal fun cleanup(addon: PylonAddon) = lockEntityWrite {
         for ((_, value) in entitiesById.filter { it.key.isFromAddon(addon) }) {
             for (entity in value) {
-                entity.write()
+                PylonEntity.serialize(entity)
             }
         }
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
@@ -58,13 +58,18 @@ object EntityStorage : Listener {
     inline fun <reified T> getAs(entity: Entity): T?
         = getAs(T::class.java, entity)
 
+    @JvmStatic
+    fun add(entity: PylonEntity<*, *>) = lockBlockWrite {
+        entities[entity.entity.uniqueId] = entity
+        entitiesByType.getOrPut(entity.schema.key) { mutableSetOf() }.add(entity)
+    }
+
     @EventHandler
     private fun onEntityLoad(event: EntitiesLoadEvent) {
         for (entity in event.entities) {
-            PylonEntity.deserialize(entity)?.let { pylonEntity -> lockBlockWrite {
-                entities[entity.uniqueId] = pylonEntity
-                entitiesByType.getOrPut(pylonEntity.schema.key) { mutableSetOf() }.add(pylonEntity)
-            }}
+            PylonEntity.deserialize(entity)?.let {
+                add(it)
+            }
         }
     }
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
@@ -136,7 +136,7 @@ object EntityStorage : Listener {
     }
 
     @JvmSynthetic
-    internal fun cleanupEverything() = {
+    internal fun cleanupEverything() {
         for (entity in entities.values) {
             entity.write()
         }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
@@ -118,10 +118,11 @@ object EntityStorage : Listener {
     }
 
     @EventHandler(ignoreCancelled = true)
-    private fun onEntityDeath(event: EntityDeathEvent)
-        = get(event.entity)?.let {
+    private fun onEntityDeath(event: EntityDeathEvent) {
+        get(event.entity)?.let {
             PylonEntityDeathEvent(it, event).callEvent()
         }
+    }
 
     @JvmSynthetic
     internal fun cleanup(addon: PylonAddon) = lockEntityWrite {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
@@ -68,7 +68,7 @@ object EntityStorage : Listener {
     inline fun <reified T> getAs(entity: Entity): T?
         = getAs(T::class.java, entity)
 
-    fun getById(id: NamespacedKey): Collection<PylonEntity<*, *>> =
+    fun getByKey(id: NamespacedKey): Collection<PylonEntity<*, *>> =
         if (PylonRegistry.ENTITIES.contains(id)) {
             lockEntityRead {
                 entitiesById[id].orEmpty()

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/PylonEntity.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/PylonEntity.kt
@@ -1,5 +1,6 @@
 package io.github.pylonmc.pylon.core.entity
 
+import com.google.common.base.Supplier
 import io.github.pylonmc.pylon.core.persistence.datatypes.PylonSerializers
 import io.github.pylonmc.pylon.core.pluginInstance
 import io.github.pylonmc.pylon.core.registry.PylonRegistry
@@ -12,6 +13,8 @@ abstract class PylonEntity<out S : PylonEntitySchema, out E: Entity> protected c
     val schema: S,
     val entity: E
 ) {
+
+    protected constructor(schema: S, supplier: Supplier<E>): this(schema, supplier.get())
 
     /**
      * Write all the state saved in the Pylon entity class to the entity's

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/PylonEntity.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/PylonEntity.kt
@@ -24,7 +24,7 @@ abstract class PylonEntity<out S : PylonEntitySchema, out E: Entity> protected c
 
     companion object {
 
-        private val pylonEntityKeyKey = pylonKey("key")
+        private val pylonEntityKeyKey = pylonKey("entity_schema_key")
 
         @JvmSynthetic
         internal fun serialize(pylonEntity: PylonEntity<*, *>) {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/PylonEntity.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/PylonEntity.kt
@@ -1,0 +1,60 @@
+package io.github.pylonmc.pylon.core.entity
+
+import io.github.pylonmc.pylon.core.persistence.datatypes.PylonSerializers
+import io.github.pylonmc.pylon.core.pluginInstance
+import io.github.pylonmc.pylon.core.registry.PylonRegistry
+import io.github.pylonmc.pylon.core.util.pylonKey
+import org.bukkit.NamespacedKey
+import org.bukkit.entity.Entity
+
+
+abstract class PylonEntity<out S : PylonEntitySchema, out E: Entity> protected constructor(
+    val schema: S,
+    val entity: E
+) {
+
+    /**
+     * Write all the state saved in the Pylon entity class to the entity's
+     * persistent data container.
+     */
+    open fun write() {}
+
+    companion object {
+
+        private val pylonEntityKeyKey = pylonKey("key")
+
+        @JvmSynthetic
+        internal fun serialize(entity: PylonEntity<*, *>) {
+            entity.entity.persistentDataContainer.set(pylonEntityKeyKey, PylonSerializers.NAMESPACED_KEY, entity.schema.key)
+            entity.write()
+        }
+
+        @JvmSynthetic
+        internal fun deserialize(entity: Entity): PylonEntity<*, *>? {
+            // Stored outside of the try block so it is displayed in error messages once acquired
+            var key: NamespacedKey? = null
+
+            try {
+                key = entity.persistentDataContainer.get(pylonEntityKeyKey, PylonSerializers.NAMESPACED_KEY)
+                    ?: return null
+
+                // We fail silently here because this may trigger if an addon is removed or fails to load.
+                // In this case, we don't want to delete the data, and we also don't want to spam errors.
+                val schema = PylonRegistry.ENTITIES[key]
+                    ?: return null
+
+                if (schema.entityClass.isInstance(entity)) {
+                    return null
+                }
+
+                @Suppress("UNCHECKED_CAST") // The cast will work - this is checked in the schema constructor
+                return schema.loadConstructor.invoke(schema, entity) as PylonEntity<*, *>
+
+            } catch (t: Throwable) {
+                pluginInstance.logger.severe("Error while loading entity $key with UUID ${entity.uniqueId}")
+                t.printStackTrace()
+                return null
+            }
+        }
+    }
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/PylonEntity.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/PylonEntity.kt
@@ -17,8 +17,8 @@ abstract class PylonEntity<out S : PylonEntitySchema, out E: Entity> protected c
     protected constructor(schema: S, supplier: Supplier<E>): this(schema, supplier.get())
 
     /**
-     * Write all the state saved in the Pylon entity class to the entity's
-     * persistent data container.
+     * Write all the state saved in the Pylon entity class to the entity's persistent data
+     * container.
      */
     open fun write() {}
 
@@ -27,9 +27,10 @@ abstract class PylonEntity<out S : PylonEntitySchema, out E: Entity> protected c
         private val pylonEntityKeyKey = pylonKey("key")
 
         @JvmSynthetic
-        internal fun serialize(entity: PylonEntity<*, *>) {
-            entity.entity.persistentDataContainer.set(pylonEntityKeyKey, PylonSerializers.NAMESPACED_KEY, entity.schema.key)
-            entity.write()
+        internal fun serialize(pylonEntity: PylonEntity<*, *>) {
+            pylonEntity.write()
+            pylonEntity.entity.persistentDataContainer
+                .set(pylonEntityKeyKey, PylonSerializers.NAMESPACED_KEY, pylonEntity.schema.key)
         }
 
         @JvmSynthetic
@@ -46,7 +47,7 @@ abstract class PylonEntity<out S : PylonEntitySchema, out E: Entity> protected c
                 val schema = PylonRegistry.ENTITIES[key]
                     ?: return null
 
-                if (schema.entityClass.isInstance(entity)) {
+                if (!schema.entityClass.isInstance(entity)) {
                     return null
                 }
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/PylonEntitySchema.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/PylonEntitySchema.kt
@@ -1,0 +1,28 @@
+package io.github.pylonmc.pylon.core.entity
+
+import io.github.pylonmc.pylon.core.registry.PylonRegistry
+import io.github.pylonmc.pylon.core.util.findConstructorMatching
+import org.bukkit.Keyed
+import org.bukkit.NamespacedKey
+import java.lang.invoke.MethodHandle
+
+
+open class PylonEntitySchema(
+    private val key: NamespacedKey,
+    val entityClass: Class<*>,
+    pylonEntityClass: Class<out PylonEntity<*, *>>,
+) : Keyed {
+
+    @JvmSynthetic
+    internal val loadConstructor: MethodHandle = pylonEntityClass.findConstructorMatching(
+        javaClass,
+        entityClass
+    )
+        ?: throw NoSuchMethodException("Entity '$key' ($pylonEntityClass) is missing a load constructor (PylonEntitySchema, Entity)")
+
+    fun register() {
+        PylonRegistry.ENTITIES.register(this)
+    }
+
+    override fun getKey(): NamespacedKey = key
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/event/PylonEntityDeathEvent.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/event/PylonEntityDeathEvent.kt
@@ -1,0 +1,20 @@
+package io.github.pylonmc.pylon.core.event
+
+import io.github.pylonmc.pylon.core.entity.PylonEntity
+import org.bukkit.event.Event
+import org.bukkit.event.HandlerList
+import org.bukkit.event.entity.EntityDeathEvent
+
+/**
+ * Called when a Pylon entity is killed
+ */
+class PylonEntityDeathEvent(val pylonEntity: PylonEntity<*, *>, event: EntityDeathEvent) : Event() {
+
+    override fun getHandlers(): HandlerList
+        = handlerList
+
+    companion object {
+        @JvmStatic
+        val handlerList: HandlerList = HandlerList()
+    }
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/event/PylonEntityLoadEvent.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/event/PylonEntityLoadEvent.kt
@@ -1,0 +1,19 @@
+package io.github.pylonmc.pylon.core.event
+
+import io.github.pylonmc.pylon.core.entity.PylonEntity
+import org.bukkit.event.Event
+import org.bukkit.event.HandlerList
+
+/**
+ * Called after a Pylon entity has been loaded
+ */
+class PylonEntityLoadEvent(val pylonEntity: PylonEntity<*, *>) : Event() {
+
+    override fun getHandlers(): HandlerList
+        = handlerList
+
+    companion object {
+        @JvmStatic
+        val handlerList: HandlerList = HandlerList()
+    }
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/event/PylonEntityUnloadEvent.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/event/PylonEntityUnloadEvent.kt
@@ -1,0 +1,19 @@
+package io.github.pylonmc.pylon.core.event
+
+import io.github.pylonmc.pylon.core.entity.PylonEntity
+import org.bukkit.event.Event
+import org.bukkit.event.HandlerList
+
+/**
+ * Called after a Pylon entity has been unloaded
+ */
+class PylonEntityUnloadEvent(val pylonEntity: PylonEntity<*, *>) : Event() {
+
+    override fun getHandlers(): HandlerList
+        = handlerList
+
+    companion object {
+        @JvmStatic
+        val handlerList: HandlerList = HandlerList()
+    }
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItemListener.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItemListener.kt
@@ -127,13 +127,10 @@ internal object PylonItemListener : Listener {
     }
 
     @EventHandler
-    private fun handle(event: EntityInteractEvent) {
-        val entity = event.entity
-        if (entity is Player) {
-            val pylonItem = PylonItem.fromStack(entity.activeItem)
-            if (pylonItem is EntityInteractor) {
-                pylonItem.onUsedToRightClickEntity(event)
-            }
+    private fun handle(event: PlayerInteractEntityEvent) {
+        val pylonItem = PylonItem.fromStack(event.player.activeItem)
+        if (pylonItem is EntityInteractor) {
+            pylonItem.onUsedToRightClickEntity(event)
         }
     }
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/base/EntityInteractor.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/base/EntityInteractor.kt
@@ -6,5 +6,5 @@ interface EntityInteractor {
     /**
      * Called when a player right clicks an entity while holding the item
      */
-    fun onUsedToRightClickEntity(event: PlayerInteractEntityEvent)
+    fun onUsedToRightClickEntity(event: PlayerInteractEntityEvent) {}
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/base/EntityInteractor.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/base/EntityInteractor.kt
@@ -6,5 +6,5 @@ interface EntityInteractor {
     /**
      * Called when a player right clicks an entity while holding the item
      */
-    fun onUsedToRightClickEntity(event: PlayerInteractEntityEvent) {}
+    fun onUsedToRightClickEntity(event: PlayerInteractEntityEvent)
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/base/EntityInteractor.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/base/EntityInteractor.kt
@@ -1,10 +1,10 @@
 package io.github.pylonmc.pylon.core.item.base
 
-import org.bukkit.event.entity.EntityInteractEvent
+import org.bukkit.event.player.PlayerInteractEntityEvent
 
 interface EntityInteractor {
     /**
      * Called when a player right clicks an entity while holding the item
      */
-    fun onUsedToRightClickEntity(event: EntityInteractEvent)
+    fun onUsedToRightClickEntity(event: PlayerInteractEntityEvent)
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/blockstorage/BlockStorage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/blockstorage/BlockStorage.kt
@@ -63,7 +63,7 @@ object BlockStorage : Listener {
      */
     private val blocksByChunk: MutableMap<ChunkPosition, MutableList<PylonBlock<*>>> = ConcurrentHashMap()
 
-    private val blocksById: MutableMap<NamespacedKey, MutableList<PylonBlock<*>>> = ConcurrentHashMap()
+    private val blocksByKey: MutableMap<NamespacedKey, MutableList<PylonBlock<*>>> = ConcurrentHashMap()
 
     @JvmStatic
     val loadedBlocks: Set<BlockPosition>
@@ -128,10 +128,10 @@ object BlockStorage : Listener {
     }
 
     @JvmStatic
-    fun getByKey(id: NamespacedKey): Collection<PylonBlock<*>> =
-        if (PylonRegistry.BLOCKS.contains(id)) {
+    fun getByKey(key: NamespacedKey): Collection<PylonBlock<*>> =
+        if (PylonRegistry.BLOCKS.contains(key)) {
             lockBlockRead {
-                blocksById[id].orEmpty()
+                blocksByKey[key].orEmpty()
             }
         } else {
             emptySet()
@@ -172,7 +172,7 @@ object BlockStorage : Listener {
         lockBlockWrite {
             check(blockPosition.chunk in blocksByChunk) { "Chunk '${blockPosition.chunk}' must be loaded" }
             blocks[blockPosition] = block
-            blocksById.getOrPut(schema.key, ::mutableListOf).add(block)
+            blocksByKey.getOrPut(schema.key, ::mutableListOf).add(block)
             blocksByChunk[blockPosition.chunk]!!.add(block)
         }
 
@@ -242,7 +242,7 @@ object BlockStorage : Listener {
 
         lockBlockWrite {
             blocks.remove(blockPosition)
-            blocksById[block.schema.key]?.remove(block)
+            blocksByKey[block.schema.key]?.remove(block)
             blocksByChunk[blockPosition.chunk]?.remove(block)
         }
 
@@ -308,7 +308,7 @@ object BlockStorage : Listener {
             blocksByChunk[event.chunk.position] = chunkBlocks.toMutableList()
             for (block in chunkBlocks) {
                 blocks[block.block.position] = block
-                blocksById.computeIfAbsent(block.schema.key) { mutableListOf() }.add(block)
+                blocksByKey.computeIfAbsent(block.schema.key) { mutableListOf() }.add(block)
             }
         }
 
@@ -326,7 +326,7 @@ object BlockStorage : Listener {
                 ?: error("Attempted to save Pylon data for chunk '${event.chunk.position}' but no data is stored")
             for (block in chunkBlocks) {
                 blocks.remove(block.block.position)
-                (blocksById[block.schema.key] ?: continue).remove(block)
+                (blocksByKey[block.schema.key] ?: continue).remove(block)
             }
             chunkBlocks
         }
@@ -362,7 +362,7 @@ object BlockStorage : Listener {
         }
 
         blocks.replaceAll { _, block -> replacer.invoke(block) }
-        for (blocks in blocksById.values) {
+        for (blocks in blocksByKey.values) {
             blocks.replaceAll(replacer)
         }
         for (blocks in blocksByChunk.values) {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/blockstorage/BlockStorage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/persistence/blockstorage/BlockStorage.kt
@@ -128,7 +128,7 @@ object BlockStorage : Listener {
     }
 
     @JvmStatic
-    fun getById(id: NamespacedKey): Collection<PylonBlock<*>> =
+    fun getByKey(id: NamespacedKey): Collection<PylonBlock<*>> =
         if (PylonRegistry.BLOCKS.contains(id)) {
             lockBlockRead {
                 blocksById[id].orEmpty()

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/registry/PylonRegistry.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/registry/PylonRegistry.kt
@@ -79,6 +79,9 @@ class PylonRegistry<T : Keyed>(val key: PylonRegistryKey<T>) : Iterable<T> {
         val BLOCKS = PylonRegistry(PylonRegistryKey.BLOCKS).also(::addRegistry)
 
         @JvmField
+        val ENTITIES = PylonRegistry(PylonRegistryKey.ENTITIES).also(::addRegistry)
+
+        @JvmField
         val ADDONS = PylonRegistry(PylonRegistryKey.ADDONS).also(::addRegistry)
 
         @JvmField

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/registry/PylonRegistryKey.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/registry/PylonRegistryKey.kt
@@ -2,6 +2,7 @@ package io.github.pylonmc.pylon.core.registry
 
 import io.github.pylonmc.pylon.core.addon.PylonAddon
 import io.github.pylonmc.pylon.core.block.PylonBlockSchema
+import io.github.pylonmc.pylon.core.entity.PylonEntitySchema
 import io.github.pylonmc.pylon.core.item.PylonItemSchema
 import io.github.pylonmc.pylon.core.mobdrop.MobDrop
 import io.github.pylonmc.pylon.core.recipe.RecipeType
@@ -23,6 +24,9 @@ data class PylonRegistryKey<T>(val namespace: String, val path: String) {
 
         @JvmField
         val BLOCKS = PylonRegistryKey<PylonBlockSchema>(pylonKey("blocks"))
+
+        @JvmField
+        val ENTITIES = PylonRegistryKey<PylonEntitySchema>(pylonKey("entities"))
 
         @JvmField
         val GAMETESTS = PylonRegistryKey<GameTestConfig>(pylonKey("gametests"))

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/PylonTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/PylonTest.java
@@ -6,6 +6,7 @@ import io.github.pylonmc.pylon.test.base.TestResult;
 import io.github.pylonmc.pylon.test.block.Blocks;
 import io.github.pylonmc.pylon.test.item.Items;
 import io.github.pylonmc.pylon.test.test.block.*;
+import io.github.pylonmc.pylon.test.test.entity.EntityStorageSimpleTest;
 import io.github.pylonmc.pylon.test.test.item.PylonItemStackInterfaceTest;
 import io.github.pylonmc.pylon.test.test.misc.GametestTest;
 import io.github.pylonmc.pylon.test.test.recipe.CraftingTest;
@@ -70,6 +71,8 @@ public class PylonTest extends JavaPlugin implements PylonAddon {
         tests.add(new CraftingTest());
         tests.add(new FurnaceTest());
         tests.add(new MobDropTest());
+
+        tests.add(new EntityStorageSimpleTest());
 
         return tests;
     }

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/PylonTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/PylonTest.java
@@ -8,6 +8,7 @@ import io.github.pylonmc.pylon.test.entity.Entities;
 import io.github.pylonmc.pylon.test.item.Items;
 import io.github.pylonmc.pylon.test.test.block.*;
 import io.github.pylonmc.pylon.test.test.entity.EntityStorageChunkReloadTest;
+import io.github.pylonmc.pylon.test.test.entity.EntityStorageMissingSchemaTest;
 import io.github.pylonmc.pylon.test.test.entity.EntityStorageSimpleTest;
 import io.github.pylonmc.pylon.test.test.item.PylonItemStackInterfaceTest;
 import io.github.pylonmc.pylon.test.test.misc.GametestTest;
@@ -75,6 +76,7 @@ public class PylonTest extends JavaPlugin implements PylonAddon {
         tests.add(new MobDropTest());
 
         tests.add(new EntityStorageSimpleTest());
+        tests.add(new EntityStorageMissingSchemaTest());
         tests.add(new EntityStorageChunkReloadTest());
 
         return tests;

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/PylonTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/PylonTest.java
@@ -4,8 +4,10 @@ import io.github.pylonmc.pylon.core.addon.PylonAddon;
 import io.github.pylonmc.pylon.test.base.Test;
 import io.github.pylonmc.pylon.test.base.TestResult;
 import io.github.pylonmc.pylon.test.block.Blocks;
+import io.github.pylonmc.pylon.test.entity.Entities;
 import io.github.pylonmc.pylon.test.item.Items;
 import io.github.pylonmc.pylon.test.test.block.*;
+import io.github.pylonmc.pylon.test.test.entity.EntityStorageChunkReloadTest;
 import io.github.pylonmc.pylon.test.test.entity.EntityStorageSimpleTest;
 import io.github.pylonmc.pylon.test.test.item.PylonItemStackInterfaceTest;
 import io.github.pylonmc.pylon.test.test.misc.GametestTest;
@@ -73,6 +75,7 @@ public class PylonTest extends JavaPlugin implements PylonAddon {
         tests.add(new MobDropTest());
 
         tests.add(new EntityStorageSimpleTest());
+        tests.add(new EntityStorageChunkReloadTest());
 
         return tests;
     }
@@ -97,6 +100,7 @@ public class PylonTest extends JavaPlugin implements PylonAddon {
         try {
             Blocks.register();
             Items.register();
+            Entities.register();
         } catch (Exception e) {
             instance().getLogger().severe("Failed to set up tests");
             e.printStackTrace();

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/entity/Entities.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/entity/Entities.java
@@ -1,0 +1,17 @@
+package io.github.pylonmc.pylon.test.entity;
+
+import io.github.pylonmc.pylon.core.entity.PylonEntitySchema;
+import io.github.pylonmc.pylon.test.PylonTest;
+import org.bukkit.entity.LivingEntity;
+
+
+public final class Entities {
+
+    private Entities() {}
+
+    public static final PylonEntitySchema SIMPLE_ENTITY = new PylonEntitySchema(
+            PylonTest.key("simple_entity"),
+            LivingEntity.class,
+            SimpleEntity.class
+    );
+}

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/entity/Entities.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/entity/Entities.java
@@ -14,4 +14,8 @@ public final class Entities {
             LivingEntity.class,
             SimpleEntity.class
     );
+
+    public static void register() {
+        SIMPLE_ENTITY.register();
+    }
 }

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/entity/SimpleEntity.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/entity/SimpleEntity.java
@@ -22,6 +22,7 @@ public class SimpleEntity extends PylonEntity<PylonEntitySchema, LivingEntity> {
         someQuantity = 69;
     }
 
+    @SuppressWarnings({"unused", "DataFlowIssue"})
     public SimpleEntity(@NotNull PylonEntitySchema schema, @NotNull LivingEntity entity) {
         super(schema, entity);
         someQuantity = entity.getPersistentDataContainer().get(key, PersistentDataType.INTEGER);

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/entity/SimpleEntity.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/entity/SimpleEntity.java
@@ -18,11 +18,11 @@ public class SimpleEntity extends PylonEntity<PylonEntitySchema, LivingEntity> {
 
     public SimpleEntity(@NotNull PylonEntitySchema schema, @NotNull Location location) {
         super(schema, location.getWorld().spawn(location, Skeleton.class));
-        getEntity().setHealth(999);
+        getEntity().setAI(false);
         someQuantity = 69;
     }
 
-    protected SimpleEntity(@NotNull PylonEntitySchema schema, @NotNull Skeleton entity) {
+    public SimpleEntity(@NotNull PylonEntitySchema schema, @NotNull LivingEntity entity) {
         super(schema, entity);
         someQuantity = entity.getPersistentDataContainer().get(key, PersistentDataType.INTEGER);
     }

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/entity/SimpleEntity.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/entity/SimpleEntity.java
@@ -1,0 +1,38 @@
+package io.github.pylonmc.pylon.test.entity;
+
+import io.github.pylonmc.pylon.core.entity.PylonEntity;
+import io.github.pylonmc.pylon.core.entity.PylonEntitySchema;
+import io.github.pylonmc.pylon.test.PylonTest;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Skeleton;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+
+
+public class SimpleEntity extends PylonEntity<PylonEntitySchema, LivingEntity> {
+
+    private final NamespacedKey key = PylonTest.key("some_quantity");
+    private final int someQuantity;
+
+    public SimpleEntity(@NotNull PylonEntitySchema schema, @NotNull Location location) {
+        super(schema, location.getWorld().spawn(location, Skeleton.class));
+        getEntity().setHealth(999);
+        someQuantity = 69;
+    }
+
+    protected SimpleEntity(@NotNull PylonEntitySchema schema, @NotNull Skeleton entity) {
+        super(schema, entity);
+        someQuantity = entity.getPersistentDataContainer().get(key, PersistentDataType.INTEGER);
+    }
+
+    @Override
+    public void write() {
+        getEntity().getPersistentDataContainer().set(key, PersistentDataType.INTEGER, someQuantity);
+    }
+
+    public int getSomeQuantity() {
+        return someQuantity;
+    }
+}

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/entity/EntityStorageChunkReloadTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/entity/EntityStorageChunkReloadTest.java
@@ -1,0 +1,50 @@
+package io.github.pylonmc.pylon.test.test.entity;
+
+import io.github.pylonmc.pylon.core.entity.EntityStorage;
+import io.github.pylonmc.pylon.test.base.AsyncTest;
+import io.github.pylonmc.pylon.test.entity.Entities;
+import io.github.pylonmc.pylon.test.entity.SimpleEntity;
+import io.github.pylonmc.pylon.test.util.TestUtil;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class EntityStorageChunkReloadTest extends AsyncTest {
+
+    @Override
+    protected void test() {
+        Chunk chunk = TestUtil.getRandomChunk(false).join();
+        Location location = chunk.getBlock(5, 100, 5).getLocation();
+        SimpleEntity pylonEntity = TestUtil.runSync(() -> new SimpleEntity(Entities.SIMPLE_ENTITY, location)).join();
+        UUID uuid = pylonEntity.getEntity().getUniqueId();
+        EntityStorage.add(pylonEntity);
+
+        assertThat(EntityStorage.isPylonEntity(uuid))
+                .isTrue();
+
+        TestUtil.unloadChunk(chunk).join();
+        TestUtil.waitUntil(() -> !chunk.isEntitiesLoaded()).join();
+
+        assertThat(EntityStorage.isPylonEntity(uuid))
+                .isFalse();
+
+        TestUtil.loadChunk(chunk).join();
+        TestUtil.waitUntil(chunk::isEntitiesLoaded).join();
+
+        assertThat(EntityStorage.isPylonEntity(uuid))
+                .isTrue();
+        assertThat(EntityStorage.get(uuid))
+                .isNotNull()
+                .isInstanceOf(SimpleEntity.class);
+        assertThat(EntityStorage.getAs(SimpleEntity.class, uuid))
+                .isNotNull()
+                .extracting(SimpleEntity::getSomeQuantity)
+                .isEqualTo(69);
+        assertThat(pylonEntity.getEntity().hasAI())
+                .isFalse();
+    }
+}

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/entity/EntityStorageMissingSchemaTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/entity/EntityStorageMissingSchemaTest.java
@@ -1,0 +1,80 @@
+package io.github.pylonmc.pylon.test.test.entity;
+
+import io.github.pylonmc.pylon.core.entity.EntityStorage;
+import io.github.pylonmc.pylon.core.entity.PylonEntity;
+import io.github.pylonmc.pylon.core.entity.PylonEntitySchema;
+import io.github.pylonmc.pylon.core.registry.PylonRegistry;
+import io.github.pylonmc.pylon.test.PylonTest;
+import io.github.pylonmc.pylon.test.base.AsyncTest;
+import io.github.pylonmc.pylon.test.util.TestUtil;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Skeleton;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class EntityStorageMissingSchemaTest extends AsyncTest {
+
+    public static class SimpleEntity extends PylonEntity<PylonEntitySchema, LivingEntity> {
+
+        public SimpleEntity(@NotNull PylonEntitySchema schema, @NotNull Location location) {
+            super(schema, location.getWorld().spawn(location, Skeleton.class));
+        }
+
+        @SuppressWarnings("unused")
+        public SimpleEntity(@NotNull PylonEntitySchema schema, @NotNull LivingEntity entity) {
+            super(schema, entity);
+        }
+    }
+
+    public static final PylonEntitySchema SIMPLE_ENTITY = new PylonEntitySchema(
+            PylonTest.key("entity_storage_missing_schema_test_entity"),
+            LivingEntity.class,
+            SimpleEntity.class
+    );
+
+    @Override
+    protected void test() {
+        SIMPLE_ENTITY.register();
+
+        Chunk chunk = TestUtil.getRandomChunk(false).join();
+        Location location = chunk.getBlock(5, 100, 5).getLocation();
+        SimpleEntity pylonEntity = TestUtil.runSync(() -> new SimpleEntity(SIMPLE_ENTITY, location)).join();
+        UUID uuid = pylonEntity.getEntity().getUniqueId();
+        EntityStorage.add(pylonEntity);
+
+        assertThat(EntityStorage.isPylonEntity(uuid))
+                .isTrue();
+        assertThat(EntityStorage.get(uuid))
+                .isNotNull()
+                .isInstanceOf(SimpleEntity.class);
+        TestUtil.unloadChunk(chunk).join();
+        TestUtil.waitUntil(() -> !chunk.isEntitiesLoaded()).join();
+
+        PylonRegistry.ENTITIES.unregister(SIMPLE_ENTITY);
+
+        TestUtil.loadChunk(chunk).join();
+        TestUtil.waitUntil(chunk::isEntitiesLoaded).join();
+        assertThat(EntityStorage.isPylonEntity(uuid))
+                .isFalse();
+        assertThat(EntityStorage.get(uuid))
+                .isNull();
+        TestUtil.unloadChunk(chunk).join();
+        TestUtil.waitUntil(() -> !chunk.isEntitiesLoaded()).join();
+
+        SIMPLE_ENTITY.register();
+
+        TestUtil.loadChunk(chunk).join();
+        TestUtil.waitUntil(chunk::isEntitiesLoaded).join();
+        assertThat(EntityStorage.isPylonEntity(uuid))
+                .isTrue();
+        assertThat(EntityStorage.get(uuid))
+                .isNotNull()
+                .isInstanceOf(SimpleEntity.class);
+    }
+}

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/entity/EntityStorageSimpleTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/entity/EntityStorageSimpleTest.java
@@ -1,0 +1,52 @@
+package io.github.pylonmc.pylon.test.test.entity;
+
+import io.github.pylonmc.pylon.core.entity.EntityStorage;
+import io.github.pylonmc.pylon.core.test.GameTestConfig;
+import io.github.pylonmc.pylon.test.PylonTest;
+import io.github.pylonmc.pylon.test.base.GameTest;
+import io.github.pylonmc.pylon.test.entity.Entities;
+import io.github.pylonmc.pylon.test.entity.SimpleEntity;
+import org.bukkit.NamespacedKey;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class EntityStorageSimpleTest extends GameTest {
+
+    public EntityStorageSimpleTest() {
+        super(new GameTestConfig.Builder(new NamespacedKey(PylonTest.instance(), "entity_storage_add_test"))
+                .size(1)
+                .setUp((test) -> {
+                    SimpleEntity pylonEntity = new SimpleEntity(Entities.SIMPLE_ENTITY, test.location());
+                    UUID uuid = pylonEntity.getEntity().getUniqueId();
+                    EntityStorage.add(pylonEntity);
+
+                    assertThat(EntityStorage.isPylonEntity(uuid))
+                            .isTrue();
+
+                    assertThat(EntityStorage.get(uuid))
+                            .isNotNull()
+                            .isInstanceOf(SimpleEntity.class);
+
+                    assertThat(EntityStorage.getAs(SimpleEntity.class, uuid))
+                            .isNotNull()
+                            .extracting(SimpleEntity::getSomeQuantity)
+                            .isEqualTo(69);
+
+                    assertThat(pylonEntity.getEntity().hasAI())
+                            .isFalse();
+
+                    pylonEntity.getEntity().remove();
+
+                    assertThat(EntityStorage.isPylonEntity(uuid))
+                            .isFalse();
+
+                    assertThat(EntityStorage.get(uuid))
+                            .isNull();
+
+                })
+                .build());
+    }
+}

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/entity/EntityStorageSimpleTest.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/test/entity/EntityStorageSimpleTest.java
@@ -25,16 +25,13 @@ public class EntityStorageSimpleTest extends GameTest {
 
                     assertThat(EntityStorage.isPylonEntity(uuid))
                             .isTrue();
-
                     assertThat(EntityStorage.get(uuid))
                             .isNotNull()
                             .isInstanceOf(SimpleEntity.class);
-
                     assertThat(EntityStorage.getAs(SimpleEntity.class, uuid))
                             .isNotNull()
                             .extracting(SimpleEntity::getSomeQuantity)
                             .isEqualTo(69);
-
                     assertThat(pylonEntity.getEntity().hasAI())
                             .isFalse();
 
@@ -42,7 +39,6 @@ public class EntityStorageSimpleTest extends GameTest {
 
                     assertThat(EntityStorage.isPylonEntity(uuid))
                             .isFalse();
-
                     assertThat(EntityStorage.get(uuid))
                             .isNull();
 


### PR DESCRIPTION
## Summary
- Adds `PylonEntity`, `PylonEntitySchema` and `PylonBlockStorage`
- Adds corresponding tests (see `tests/entity/**`)
- Adds checks to blocks, items, and entities to make sure the schema being used to create a new instance has been registered (this has tripped me up a few times)
- Updates debug item to show pdc of entities
- Fixes EntityInteractor
- Fixes some registries not being unregistered when an addon is disabled

## Future work
### Entity interfaces PR
- Interfaces (ticking, right click handlers, death handlers, etc)
- TickManager for entities
- Ticker tests
- Ticker error tests
- Entity holder blocks

### Composite entity / display model PR
- Acquire a large quantity of alcohol

### Display entity PR)
- Transformation builder
- Block, line, item, text, interaction
- Interaction callbacks would be so nice
- Animations?