### PR TITLE
Force items to have the same material as placed block

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockStorage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockStorage.kt
@@ -195,7 +195,6 @@ object BlockStorage : Listener {
         event.callEvent()
         if (event.isCancelled) return null
 
-        event.block.type = block.getPlaceMaterial(event.block, context)
         lockBlockWrite {
             check(blockPosition.chunk in blocksByChunk) { "Chunk '${blockPosition.chunk}' must be loaded" }
             blocks[blockPosition] = block

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlock.kt
@@ -52,10 +52,6 @@ open class PylonBlock protected constructor(val block: Block) {
         }
     }
 
-    open fun getPlaceMaterial(block: Block, context: BlockCreateContext): Material {
-        return schema.material
-    }
-
     open fun write(pdc: PersistentDataContainer) {}
 
     fun getSettings(): Config

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItemSchema.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItemSchema.kt
@@ -4,6 +4,7 @@ import io.github.pylonmc.pylon.core.block.BlockStorage
 import io.github.pylonmc.pylon.core.block.PylonBlock
 import io.github.pylonmc.pylon.core.block.context.BlockCreateContext
 import io.github.pylonmc.pylon.core.datatypes.PylonSerializers
+import io.github.pylonmc.pylon.core.registry.PylonRegistry
 import io.github.pylonmc.pylon.core.registry.RegistryHandler
 import io.github.pylonmc.pylon.core.util.findConstructorMatching
 import io.github.pylonmc.pylon.core.util.key.getAddon
@@ -39,7 +40,11 @@ class PylonItemSchema @JvmOverloads internal constructor(
         if (pylonBlockKey == null) {
             return null
         }
-        check(template.type.isBlock) { "Material ${template.type} is not a block" }
+        val blockSchema = PylonRegistry.BLOCKS[pylonBlockKey]
+        check(blockSchema != null) { "Block $pylonBlockKey not found" }
+        check(template.type == blockSchema.material) {
+            "Item $key places block $pylonBlockKey and so must have the same type - but the item is of type + ${template.type} while the block is of type ${blockSchema.material}"
+        }
         if (BlockStorage.isPylonBlock(block)) { // special case: you can place on top of structure void blocks
             return null
         }


### PR DESCRIPTION
I held off doing this because we didn't agree to do it on Discord, but have since realised that it doesn't really matter anyway because we can use item models. Fixes the current issue with blocks not being rotated to match the placement direction