### PR TITLE
Idras random fixes

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockListener.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockListener.kt
@@ -49,7 +49,7 @@ internal object BlockListener : Listener {
         val pylonItem = PylonItem.fromStack(item)
         val context = BlockCreateContext.PlayerPlace(player, item)
 
-        val pylonBlock = pylonItem?.schema?.place(context, event.block)
+        val pylonBlock = pylonItem?.place(context, event.block)
         if (pylonItem != null && pylonBlock == null) {
             event.isCancelled = true
         }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockStorage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockStorage.kt
@@ -184,6 +184,10 @@ object BlockStorage : Listener {
         val schema = PylonRegistry.BLOCKS[key]
         require(schema != null) { "Block $key does not exist" }
 
+        if (context !is BlockCreateContext.PlayerPlace) {
+            blockPosition.block.type = schema.material
+        }
+
         @Suppress("UNCHECKED_CAST") // The cast will work - this is checked in the schema constructor
         val block = schema.create(blockPosition.block, context)
         val event = PrePylonBlockPlaceEvent(blockPosition.block, block, context)

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlock.kt
@@ -74,9 +74,9 @@ open class PylonBlock protected constructor(val block: Block) {
             }
 
             for (locale in schema.addon.languages) {
-                val wailaKey = "pylon.${schema.key.namespace}.item.${schema.key.key}.waila"
-                if (!translator.translationKeyExists(wailaKey, locale)) {
-                    PylonCore.logger.warning("Block ${schema.key} is missing a WAILA translation key (${locale.displayName} | $wailaKey")
+                val translationKey = "pylon.${schema.key.namespace}.item.${schema.key.key}.waila"
+                if (!translator.translationKeyExists(translationKey, locale)) {
+                    PylonCore.logger.warning("${schema.key.namespace} is missing a WAILA translation key for block ${schema.key} (locale: ${locale.displayName} | expected translation key: $translationKey")
                 }
             }
         }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlock.kt
@@ -145,6 +145,7 @@ open class PylonBlock protected constructor(val block: Block) {
                 PylonCore.logger.severe("Error while loading block $key at $position")
                 t.printStackTrace()
                 return if (key != null && position != null) {
+                    PylonBlockSchema.schemaCache[position] = PhantomBlock.schema
                     PhantomBlock(pdc, key, position.block)
                 } else {
                     null

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/PylonBlock.kt
@@ -71,7 +71,7 @@ open class PylonBlock protected constructor(val block: Block) {
             }
 
             for (locale in schema.addon.languages) {
-                val wailaKey = WailaConfig.getWailaTranslationKey(schema.key)
+                val wailaKey = "pylon.${schema.key.namespace}.item.${schema.key.key}.waila"
                 if (!translator.translationKeyExists(wailaKey, locale)) {
                     PylonCore.logger.warning("Block ${schema.key} is missing a WAILA translation key (${locale.displayName} | $wailaKey")
                 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/TickManager.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/TickManager.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import org.bukkit.Bukkit
 import org.bukkit.Color.RED
 import org.bukkit.entity.BlockDisplay
 import org.bukkit.event.EventHandler
@@ -93,7 +94,9 @@ object TickManager : Listener {
                 display.glowColorOverride = RED
                 display.isGlowing = true
                 pylonBlock.errorBlock = display
+            }
 
+            if (errors >= PylonConfig.allowedBlockErrors) {
                 cancel()
             }
         }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonFluidBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonFluidBlock.kt
@@ -8,8 +8,8 @@ interface PylonFluidBlock {
      * Returns a map of fluid types - and their corresponding amounts - that can be supplied by
      * a particular connection point. deltaSeconds is the time since the last fluid tick.
      *
-     * This is per tick, so if you have a machine that can supply up to 100 fluid per second,
-     * it should supply 100 of that fluid
+     * If you have a machine that can supply up to 100 fluid per second, it should supply
+     * 100*deltaSeconds of that fluid
      *
      * Any implementation of this method must NEVER call the same method for another connection
      * point, otherwise you risk creating infinite loops.
@@ -21,8 +21,8 @@ interface PylonFluidBlock {
      * a particular connection point. For example, a tank should request enough fluid to fill up
      * to capacity.
      *
-     * This is per second, so if you have a machine that consumes 100 fluid per second,
-     * it should request 100 of that fluid
+     * If you have a machine that consumes 100 fluid per second, it should request
+     * 100*deltaSeconds of that fluid
      *
      * Any implementation of this method must NEVER call the same method for another connection
      * point, otherwise you risk creating infinite loops.

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/waila/WailaConfig.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/waila/WailaConfig.kt
@@ -18,17 +18,12 @@ data class WailaConfig @JvmOverloads constructor(
         val player = bar.viewers().singleOrNull() as? Player
         if (player != null) {
             val attacher = PlaceholderAttacher(placeholders)
-            bar.name(attacher.render(Component.translatable(getWailaTranslationKey(key)), Unit))
+            bar.name(attacher.render(Component.translatable("pylon.${key.namespace}.item.${key.key}.waila"), Unit))
         } else {
-            bar.name(Component.translatable(getWailaTranslationKey(key)))
+            bar.name(Component.translatable("pylon.${key.namespace}.item.${key.key}.waila"))
         }
         bar.color(color)
         bar.overlay(style)
         bar.progress(progress)
-    }
-
-    companion object {
-        fun getWailaTranslationKey(key: NamespacedKey): String
-            = "pylon.${key.namespace}.block.${key.key}"
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
@@ -109,6 +109,14 @@ object EntityStorage : Listener {
         }
     }
 
+    /**
+     * Schedules a task to run when the entity with id [uuid] is loaded, or runs the task immediately
+     * if the entity is already loaded
+     */
+    @JvmStatic
+    inline fun <reified T: PylonEntity<*>> whenEntityLoads(uuid: UUID, crossinline consumer: (T) -> Unit)
+            = whenEntityLoads(uuid, T::class.java) { t -> consumer(t) }
+
     @JvmStatic
     fun isPylonEntity(uuid: UUID): Boolean
         = get(uuid) != null

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/EntityStorage.kt
@@ -21,6 +21,7 @@ import org.bukkit.event.world.EntitiesLoadEvent
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantReadWriteLock
+import java.util.function.Consumer
 import kotlin.random.Random
 
 
@@ -29,6 +30,7 @@ object EntityStorage : Listener {
     private val entities: MutableMap<UUID, PylonEntity<*>> = ConcurrentHashMap()
     private val entitiesByKey: MutableMap<NamespacedKey, MutableSet<PylonEntity<*>>> = ConcurrentHashMap()
     private val entityAutosaveTasks: MutableMap<UUID, Job> = ConcurrentHashMap()
+    private val whenEntityLoadsTasks: MutableMap<UUID, MutableSet<Consumer<PylonEntity<*>>>> = ConcurrentHashMap()
 
     val loadedEntities: Collection<PylonEntity<*>>
         get() = entities.values
@@ -64,6 +66,7 @@ object EntityStorage : Listener {
     inline fun <reified T> getAs(entity: Entity): T?
         = getAs(T::class.java, entity)
 
+    @JvmStatic
     fun getByKey(key: NamespacedKey): Collection<PylonEntity<*>> =
         if (key in PylonRegistry.ENTITIES) {
             lockEntityRead {
@@ -72,6 +75,39 @@ object EntityStorage : Listener {
         } else {
             emptySet()
         }
+
+    /**
+     * Schedules a task to run when the entity with id [uuid] is loaded, or runs the task immediately
+     * if the entity is already loaded
+     */
+    @JvmStatic
+    fun whenEntityLoads(uuid: UUID, consumer: Consumer<PylonEntity<*>>) {
+        val pylonEntity = get(uuid)
+        if (pylonEntity != null) {
+            consumer.accept(pylonEntity)
+        } else {
+            whenEntityLoadsTasks.getOrPut(uuid) { mutableSetOf() }.add {
+                consumer.accept(it)
+            }
+        }
+
+    }
+
+    /**
+     * Schedules a task to run when the entity with id [uuid] is loaded, or runs the task immediately
+     * if the entity is already loaded
+     */
+    @JvmStatic
+    fun <T: PylonEntity<*>> whenEntityLoads(uuid: UUID, clazz: Class<T>, consumer: Consumer<T>) {
+        val pylonEntity = getAs(clazz, uuid)
+        if (pylonEntity != null) {
+            consumer.accept(pylonEntity)
+        } else {
+            whenEntityLoadsTasks.getOrPut(uuid) { mutableSetOf() }.add {
+                consumer.accept(getAs(clazz, uuid) ?: throw IllegalStateException("Entity $uuid was not of expected type ${clazz.simpleName}"))
+            }
+        }
+    }
 
     @JvmStatic
     fun isPylonEntity(uuid: UUID): Boolean
@@ -108,6 +144,19 @@ object EntityStorage : Listener {
         for (entity in event.entities) {
             val pylonEntity = PylonEntity.deserialize(entity) ?: continue
             add(pylonEntity)
+
+            val tasks = whenEntityLoadsTasks[pylonEntity.uuid]
+            if (tasks != null) {
+                for (task in tasks) {
+                    try {
+                        task.accept(pylonEntity)
+                    } catch (t: Throwable) {
+                        t.printStackTrace()
+                    }
+                }
+                whenEntityLoadsTasks.remove(pylonEntity.uuid)
+            }
+
             PylonEntityLoadEvent(pylonEntity).callEvent()
         }
     }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/display/BlockDisplayBuilder.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/display/BlockDisplayBuilder.kt
@@ -17,7 +17,7 @@ class BlockDisplayBuilder() {
     private var blockData: BlockData? = null
     private var transformation: Matrix4f? = null
     private var glowColor: Color? = null
-    private var brightness: Int? = null
+    private var brightness: Brightness? = null
     private var viewRange: Float? = null
     private var interpolationDelay: Int? = null
     private var interpolationDuration: Int? = null
@@ -41,7 +41,8 @@ class BlockDisplayBuilder() {
     fun blockData(blockData: BlockData?): BlockDisplayBuilder = apply { this.blockData = blockData }
     fun transformation(transformation: Matrix4f?): BlockDisplayBuilder = apply { this.transformation = transformation }
     fun transformation(builder: TransformBuilder): BlockDisplayBuilder = apply { this.transformation = builder.buildForBlockDisplay() }
-    fun brightness(brightness: Int): BlockDisplayBuilder = apply { this.brightness = brightness }
+    fun brightness(brightness: Brightness): BlockDisplayBuilder = apply { this.brightness = brightness }
+    fun brightness(brightness: Int): BlockDisplayBuilder = brightness(Brightness(0, brightness))
     fun glow(glowColor: Color?): BlockDisplayBuilder = apply { this.glowColor = glowColor }
     fun viewRange(viewRange: Float): BlockDisplayBuilder = apply { this.viewRange = viewRange }
     fun interpolationDelay(interpolationDelay: Int): BlockDisplayBuilder = apply { this.interpolationDelay = interpolationDelay }
@@ -69,7 +70,7 @@ class BlockDisplayBuilder() {
             display.glowColorOverride = glowColor
         }
         if (brightness != null) {
-            display.brightness = Brightness(brightness!!, 0)
+            display.brightness = brightness
         }
         if (viewRange != null) {
             display.viewRange = viewRange!!

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/display/ItemDisplayBuilder.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/display/ItemDisplayBuilder.kt
@@ -17,7 +17,7 @@ class ItemDisplayBuilder() {
 
     var itemStack: ItemStack? = null
     var transformation: Matrix4f? = null
-    var brightness: Int? = null
+    var brightness: Brightness? = null
     var glowColor: Color? = null
     var billboard: Display.Billboard? = null
     var viewRange: Float? = null
@@ -39,7 +39,8 @@ class ItemDisplayBuilder() {
     fun itemStack(itemStack: ItemStack?): ItemDisplayBuilder = apply { this.itemStack = itemStack }
     fun transformation(transformation: Matrix4f?): ItemDisplayBuilder = apply { this.transformation = transformation }
     fun transformation(builder: TransformBuilder): ItemDisplayBuilder = apply { this.transformation = builder.buildForItemDisplay() }
-    fun brightness(brightness: Int): ItemDisplayBuilder = apply { this.brightness = brightness }
+    fun brightness(brightness: Brightness): ItemDisplayBuilder = apply { this.brightness = brightness }
+    fun brightness(brightness: Int): ItemDisplayBuilder = brightness(Brightness(0, brightness))
     fun glow(glowColor: Color?): ItemDisplayBuilder = apply { this.glowColor = glowColor }
     fun billboard(billboard: Billboard?): ItemDisplayBuilder = apply { this.billboard = billboard }
     fun viewRange(viewRange: Float): ItemDisplayBuilder = apply { this.viewRange = viewRange }
@@ -68,7 +69,7 @@ class ItemDisplayBuilder() {
             display.glowColorOverride = glowColor
         }
         if (brightness != null) {
-            display.brightness = Brightness(brightness!!, 0)
+            display.brightness = brightness
         }
         if (billboard != null) {
             display.billboard = billboard!!

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/display/TextDisplayBuilder.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/entity/display/TextDisplayBuilder.kt
@@ -16,7 +16,7 @@ class TextDisplayBuilder() {
 
     private var text: Component? = null
     private var transformation: Matrix4f? = null
-    private var brightness: Int? = null
+    private var brightness: Brightness? = null
     private var glowColor: Color? = null
     private var viewRange: Float? = null
     private var billboard: Billboard? = null
@@ -42,7 +42,8 @@ class TextDisplayBuilder() {
     fun text(text: Component?): TextDisplayBuilder = apply { this.text = text }
     fun transformation(transformation: Matrix4f?): TextDisplayBuilder = apply { this.transformation = transformation }
     fun transformation(builder: TransformBuilder): TextDisplayBuilder = apply { this.transformation = builder.buildForTextDisplay() }
-    fun brightness(brightness: Int): TextDisplayBuilder = apply { this.brightness = brightness }
+    fun brightness(brightness: Brightness): TextDisplayBuilder = apply { this.brightness = brightness }
+    fun brightness(brightness: Int): TextDisplayBuilder = brightness(Brightness(0, brightness))
     fun glow(glowColor: Color?): TextDisplayBuilder = apply { this.glowColor = glowColor }
     fun viewRange(viewRange: Float): TextDisplayBuilder = apply { this.viewRange = viewRange }
     fun billboard(billboard: Billboard?): TextDisplayBuilder = apply { this.billboard = billboard }
@@ -67,7 +68,7 @@ class TextDisplayBuilder() {
             display.setTransformationMatrix(transformation!!)
         }
         if (brightness != null) {
-            display.brightness = Brightness(brightness!!, 0)
+            display.brightness = brightness
         }
         if (glowColor != null) {
             display.isGlowing = true

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidConnectionPoint.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidConnectionPoint.kt
@@ -23,6 +23,14 @@ data class FluidConnectionPoint(
     constructor(block: Block, name: String, type: Type)
             : this (UUID.randomUUID(), block.position, name, type, mutableSetOf())
 
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return other is FluidConnectionPoint && other.id == id
+    }
+
     enum class Type {
         INPUT, // input to the attached machine
         OUTPUT, // output from the attached machine

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidConnectionPoint.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidConnectionPoint.kt
@@ -10,8 +10,6 @@ import java.util.*
  *
  * The FluidConnectionPoint class is created in memory for every loaded point. FluidConnectionPoints
  * are persisted when unloaded, but do not store the segment UUID - this is decided at runtime.
- *
- * The flow rate of a segment is the lowest maxFlowRate of any point in the segment.
  */
 data class FluidConnectionPoint(
     val id: UUID,

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidManager.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidManager.kt
@@ -113,7 +113,7 @@ object FluidManager {
     }
 
     /**
-     * Call when removing a connection point, or when one has been unloaded
+     * Call when removing a connection point. Use [unload] for when a connection point is unloaded.
      */
     @JvmStatic
     fun remove(point: FluidConnectionPoint) {
@@ -125,6 +125,18 @@ object FluidManager {
                 disconnect(point, it)
             }
         }
+
+        removeFromSegment(point)
+
+        points.remove(point.id)
+    }
+
+    /**
+     * Removes a connection point from the cache, but keeps its connection information intact.
+     */
+    @JvmStatic
+    fun unload(point: FluidConnectionPoint) {
+        check(point.id in points) { "Nonexistant connection point" }
 
         removeFromSegment(point)
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidManager.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidManager.kt
@@ -175,8 +175,15 @@ object FluidManager {
         segments[segment]!!.predicate = predicate
     }
 
+    @JvmStatic
+    fun getFluidPredicate(segment: UUID): Predicate<PylonFluid>? {
+        check(segment in segments) { "Segment does not exist" }
+        return segments[segment]!!.predicate
+    }
+
     /**
-     * Connects two points - and all their connected points - into one segment
+     * Connects two points - and all their connected points - into one segment. Preserves the
+     * flow rate and predicate of the first point's segment.
      */
     @JvmStatic
     fun connect(point1: FluidConnectionPoint, point2: FluidConnectionPoint) {
@@ -187,6 +194,8 @@ object FluidManager {
             return
         }
 
+        val fluidPerSecond = getFluidPerSecond(point1.segment)
+        val fluidPredicate = getFluidPredicate(point1.segment)
 
         if (point1.segment != point2.segment) {
             val newSegment = point2.segment
@@ -194,6 +203,10 @@ object FluidManager {
                 removeFromSegment(point)
                 point.segment = newSegment
                 addToSegment(point)
+            }
+            setFluidPerSecond(newSegment, fluidPerSecond)
+            if (fluidPredicate != null) {
+                setFluidPredicate(newSegment, fluidPredicate)
             }
         }
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidManager.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidManager.kt
@@ -144,6 +144,12 @@ object FluidManager {
         segments[segment]!!.fluidPerSecond = fluidPerSecond
     }
 
+    @JvmStatic
+    fun getFluidPerSecond(segment: UUID): Double {
+        check(segment in segments) { "Segment does not exist" }
+        return segments[segment]!!.fluidPerSecond
+    }
+
     /**
      * Sets the fluid predicate for a segment. The segment will only transfer fluids that match the
      * predicate.

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidManager.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidManager.kt
@@ -175,8 +175,6 @@ object FluidManager {
             return
         }
 
-        point1.connectedPoints.add(point2.id)
-        point2.connectedPoints.add(point1.id)
 
         if (point1.segment != point2.segment) {
             val newSegment = point2.segment
@@ -186,6 +184,9 @@ object FluidManager {
                 addToSegment(point)
             }
         }
+
+        point1.connectedPoints.add(point2.id)
+        point2.connectedPoints.add(point1.id)
 
         PylonFluidPointConnectEvent(point1, point2).callEvent()
     }
@@ -210,7 +211,7 @@ object FluidManager {
 
         val connectedToPoint1 = getAllConnected(point1)
         if (point2 !in connectedToPoint1) {
-            // points are still (indirectly) connected
+            // points no longer (even indirectly) connected
             val newSegment = UUID.randomUUID()
             segments[newSegment] = Segment(
                 mutableSetOf(),

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItem.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItem.kt
@@ -101,5 +101,10 @@ open class PylonItem(val stack: ItemStack) : Keyed {
                 ?: return null
             return schema.itemClass.cast(schema.loadConstructor.invoke(stack))
         }
+
+        @JvmStatic
+        fun isPylonitem(stack: ItemStack?): Boolean {
+            return stack != null && stack.persistentDataContainer.has(PylonItemSchema.pylonItemKeyKey)
+        }
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItem.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItem.kt
@@ -1,6 +1,8 @@
 package io.github.pylonmc.pylon.core.item
 
 import io.github.pylonmc.pylon.core.PylonCore
+import io.github.pylonmc.pylon.core.block.PylonBlock
+import io.github.pylonmc.pylon.core.block.context.BlockCreateContext
 import io.github.pylonmc.pylon.core.config.Settings
 import io.github.pylonmc.pylon.core.datatypes.PylonSerializers
 import io.github.pylonmc.pylon.core.i18n.AddonTranslator
@@ -10,6 +12,7 @@ import net.kyori.adventure.text.ComponentLike
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
 import org.bukkit.Keyed
 import org.bukkit.NamespacedKey
+import org.bukkit.block.Block
 import org.bukkit.inventory.ItemStack
 import org.jetbrains.annotations.Contract
 
@@ -35,6 +38,9 @@ open class PylonItem(val stack: ItemStack) : Keyed {
 
     open fun getPlaceholders(): Map<String, ComponentLike>
         = emptyMap()
+
+    open fun place(context: BlockCreateContext, block: Block): PylonBlock?
+        = schema.place(context, block)
 
     companion object {
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItem.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItem.kt
@@ -111,7 +111,7 @@ open class PylonItem(val stack: ItemStack) : Keyed {
         }
 
         @JvmStatic
-        fun isPylonitem(stack: ItemStack?): Boolean {
+        fun isPylonItem(stack: ItemStack?): Boolean {
             return stack != null && stack.persistentDataContainer.has(PylonItemSchema.pylonItemKeyKey)
         }
 

--- a/pylon-core/src/main/resources/lang/en.yml
+++ b/pylon-core/src/main/resources/lang/en.yml
@@ -8,13 +8,11 @@ item:
   phantom_block:
     name: "<red>Phantom Block (%block%)"
     lore: ""
+    waila: "<red>Phantom Block (%block%)"
 
   debug_waxed_weathered_cut_copper_stairs:
     name: "<red>Debug Waxed Weathered Cut Copper Stairs"
     lore: "<insn>Right click</insn> a block to view its Pylon block data"
-
-block:
-  phantom_block: "<red>Phantom Block (%block%)"
 
 message:
   debug:


### PR DESCRIPTION
not ready yet
- allow setting item display / text display / block display builder brightness using `Brightness`
- fix missing schema cache assignment when creating phantom blocks after an exception loading a block
- fix placeBlock not setting the block type when a plugin places a block
- add getFluidPerSecond
- fix insane fluid manager buffoonery
- add isPylonItem
- allow item placement logic to be overriden in the item class
- fix flow rate and predicate not being preserved when merging fluid networks
- add whenEntityLoads (this is because sometimes an entity needs to do something with another entity after it's loaded - I encountered it in Aircraft and again in several fluid items)
- fix ticking tasks not being cancelled after erroring if they were previously cancelled due to erroring before being reloaded