### PR TITLE
PylonSneakableBlock and PylonJumpableBlock Events

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockListener.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockListener.kt
@@ -497,10 +497,11 @@ internal object BlockListener : Listener {
             * Event player is from before the event is triggered, so when the player
             * is marked as *not* sneaking, they just toggled it.
             */
-            if (!event.player.isSneaking)
+            if (!event.player.isSneaking) {
                 pylonBlock.onSneakStart(event)
-            if (event.player.isSneaking)
+            } else {
                 pylonBlock.onSneakEnd(event)
+            }
         }
     }
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockListener.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockListener.kt
@@ -490,7 +490,7 @@ internal object BlockListener : Listener {
 
     @EventHandler
     private fun onPlayerToggleSneak(event: PlayerToggleSneakEvent) {
-        val block = event.player.location.add(0.0, -1.0,0.0).block
+        val block = event.player.location.add(0.0, -1.0, 0.0).block
         val pylonBlock = BlockStorage.get(block)
         if (pylonBlock is PylonSneakableBlock) {
             /*

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockListener.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockListener.kt
@@ -1,6 +1,7 @@
 package io.github.pylonmc.pylon.core.block
 
 import com.destroystokyo.paper.event.block.BeaconEffectEvent
+import com.destroystokyo.paper.event.player.PlayerJumpEvent
 import io.github.pylonmc.pylon.core.block.base.*
 import io.github.pylonmc.pylon.core.block.context.BlockBreakContext
 import io.github.pylonmc.pylon.core.event.PylonBlockUnloadEvent
@@ -28,6 +29,7 @@ import org.bukkit.event.inventory.FurnaceBurnEvent
 import org.bukkit.event.inventory.FurnaceExtractEvent
 import org.bukkit.event.player.PlayerTakeLecternBookEvent
 import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.event.player.PlayerToggleSneakEvent
 
 
 /**
@@ -483,6 +485,31 @@ internal object BlockListener : Listener {
         val pylonBlock = BlockStorage.get(event.clickedBlock ?: return)
         if (pylonBlock is PylonInteractableBlock) {
             pylonBlock.onInteract(event)
+        }
+    }
+
+    @EventHandler
+    private fun onPlayerToggleSneak(event: PlayerToggleSneakEvent) {
+        val block = event.player.location.add(0.0, -1.0,0.0).block
+        val pylonBlock = BlockStorage.get(block)
+        if (pylonBlock is PylonSneakableBlock) {
+            /*
+            * Event player is from before the event is triggered, so when the player
+            * is marked as *not* sneaking, they just toggled it.
+            * */
+            if (!event.player.isSneaking)
+                pylonBlock.onSneakStart(event)
+            if (event.player.isSneaking)
+                pylonBlock.onSneakEnd(event)
+        }
+    }
+
+    @EventHandler
+    private fun onPlayerJumpEvent(event: PlayerJumpEvent) {
+        val block = event.player.location.add(0.0, -1.0,0.0).block
+        val pylonBlock = BlockStorage.get(block)
+        if (pylonBlock is PylonJumpableBlock) {
+            pylonBlock.onJump(event)
         }
     }
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockListener.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockListener.kt
@@ -496,7 +496,7 @@ internal object BlockListener : Listener {
             /*
             * Event player is from before the event is triggered, so when the player
             * is marked as *not* sneaking, they just toggled it.
-            * */
+            */
             if (!event.player.isSneaking)
                 pylonBlock.onSneakStart(event)
             if (event.player.isSneaking)

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockListener.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/BlockListener.kt
@@ -507,7 +507,7 @@ internal object BlockListener : Listener {
 
     @EventHandler
     private fun onPlayerJumpEvent(event: PlayerJumpEvent) {
-        val block = event.player.location.add(0.0, -1.0,0.0).block
+        val block = event.player.location.add(0.0, -1.0, 0.0).block
         val pylonBlock = BlockStorage.get(block)
         if (pylonBlock is PylonJumpableBlock) {
             pylonBlock.onJump(event)

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonJumpableBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonJumpableBlock.kt
@@ -1,0 +1,7 @@
+package io.github.pylonmc.pylon.core.block.base
+
+import com.destroystokyo.paper.event.player.PlayerJumpEvent
+
+interface PylonJumpableBlock {
+    fun onJump(event: PlayerJumpEvent) {}
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonSneakableBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonSneakableBlock.kt
@@ -1,0 +1,8 @@
+package io.github.pylonmc.pylon.core.block.base
+
+import org.bukkit.event.player.PlayerToggleSneakEvent
+
+interface PylonSneakableBlock {
+    fun onSneakStart(event: PlayerToggleSneakEvent) {}
+    fun onSneakEnd(event: PlayerToggleSneakEvent) {}
+}


### PR DESCRIPTION
Created for blocks that would need to know what a player is doing on top of them (e.g. elevator).

On the PylonSneakableBlock: I added both onSneakStart and onSneakEnd so developers won't try using the player on the toggle event and have isSneaking be inverted.