### PR TITLE
Hydraulic machines fixes

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonGuiBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonGuiBlock.kt
@@ -36,18 +36,16 @@ interface PylonGuiBlock : PylonBreakHandler, PylonInteractableBlock {
         if (
             event.action.isRightClick &&
             event.hand == EquipmentSlot.HAND &&
-            event.useInteractedBlock() != Event.Result.DENY
+            event.useInteractedBlock() != Event.Result.DENY &&
+            !event.player.isSneaking
         ) {
-            event.setUseInteractedBlock(Event.Result.DENY)
-            if (!event.player.isSneaking) {
-                event.setUseItemInHand(Event.Result.DENY)
-                val window = Window.single()
-                    .setGui(gui)
-                    .setTitle(AdventureComponentWrapper((this as PylonBlock).name))
-                    .setViewer(event.player)
-                    .build()
-                window.open()
-            }
+            event.setUseItemInHand(Event.Result.DENY)
+            val window = Window.single()
+                .setGui(gui)
+                .setTitle(AdventureComponentWrapper((this as PylonBlock).name))
+                .setViewer(event.player)
+                .build()
+            window.open()
         }
     }
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonSimpleMultiblock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonSimpleMultiblock.kt
@@ -29,7 +29,7 @@ import kotlin.math.min
 
 interface PylonSimpleMultiblock : PylonMultiblock, PylonEntityHolderBlock {
 
-    interface Component {
+    interface MultiblockComponent {
         fun matches(block: Block): Boolean
         fun spawnGhostBlock(block: Block): UUID
     }
@@ -54,7 +54,7 @@ interface PylonSimpleMultiblock : PylonMultiblock, PylonEntityHolderBlock {
         }
     }
 
-    data class VanillaComponent(val material: Material) : Component {
+    data class VanillaMultiblockComponent(val material: Material) : MultiblockComponent {
         override fun matches(block: Block): Boolean
             = !BlockStorage.isPylonBlock(block) && block.type == material
 
@@ -68,7 +68,7 @@ interface PylonSimpleMultiblock : PylonMultiblock, PylonEntityHolderBlock {
         }
     }
 
-    data class PylonComponent(val key: NamespacedKey) : Component {
+    data class PylonMultiblockComponent(val key: NamespacedKey) : MultiblockComponent {
         override fun matches(block: Block): Boolean
             = BlockStorage.get(block)?.schema?.key == key
 
@@ -87,9 +87,9 @@ interface PylonSimpleMultiblock : PylonMultiblock, PylonEntityHolderBlock {
     /**
      * Rotation will automatically be accounted for.
      */
-    val components: Map<Vector3i, Component>
+    val components: Map<Vector3i, MultiblockComponent>
 
-    fun validStructures(): List<Map<Vector3i, Component>> = listOf(
+    fun validStructures(): List<Map<Vector3i, MultiblockComponent>> = listOf(
         // 0 degrees
         components,
         // 90 degrees (anticlockwise)

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/ConfigSection.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/ConfigSection.kt
@@ -1,7 +1,11 @@
 package io.github.pylonmc.pylon.core.config
 
 import com.google.common.base.CaseFormat
+import io.github.pylonmc.pylon.core.registry.PylonRegistry
+import org.bukkit.Material
+import org.bukkit.NamespacedKey
 import org.bukkit.configuration.ConfigurationSection
+import org.bukkit.inventory.ItemStack
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
@@ -25,6 +29,45 @@ open class ConfigSection(val internalSection: ConfigurationSection) {
 
     fun getSectionOrThrow(key: String): ConfigSection =
         getSection(key) ?: throw KeyNotFoundException(internalSection.currentPath, key)
+
+    fun getItem(key: String): ItemStack? {
+        if (key.contains(':')) {
+            val namespacedKey = NamespacedKey.fromString(key)
+            if (namespacedKey != null) {
+                val pylonItem = PylonRegistry.ITEMS[namespacedKey]
+                if (pylonItem != null) {
+                    return pylonItem.itemStack
+                }
+            }
+        }
+
+        val material = Material.getMaterial(key.uppercase())
+        if (material != null) {
+            return ItemStack(material)
+        }
+
+        return null
+    }
+
+    fun getItemOrThrow(key: String): ItemStack {
+        if (key.contains(':')) {
+            val namespacedKey = NamespacedKey.fromString(key)
+            if (namespacedKey != null) {
+                val pylonItem = PylonRegistry.ITEMS[namespacedKey]
+                if (pylonItem != null) {
+                    return pylonItem.itemStack
+                }
+                error("No such Pylon item $key")
+            }
+        }
+
+        val material = Material.getMaterial(key.uppercase())
+        if (material != null) {
+            return ItemStack(material)
+        }
+
+        error("No such material $key")
+    }
 
     fun <T> get(key: String, type: Class<out T>): T? {
         val value = internalSection.get(key) ?: return null

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/guide/pages/SearchItemsAndFluidsPage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/guide/pages/SearchItemsAndFluidsPage.kt
@@ -21,26 +21,32 @@ class SearchItemsAndFluidsPage : SearchPage(
 
     fun getItemButtons(player: Player): MutableList<Pair<Item, String>> = PylonRegistry.ITEMS.getKeys().filter {
         !PylonGuide.hiddenItems.contains(it)
-    }.map {
+    }.mapNotNull {
         val translator = AddonTranslator.translators[getAddon(it)]!!
         val name = translator.translate(
             Component.translatable("pylon.${it.namespace}.item.${it.key}.name"), player.locale()
         )
-        check(name != null)
-        val plainTextName = serializer.serialize(name).lowercase()
-        Pair(ItemButton(it), plainTextName)
+        if (name == null) {
+            null
+        } else {
+            val plainTextName = serializer.serialize(name).lowercase()
+            Pair(ItemButton(it), plainTextName)
+        }
     }.toMutableList()
 
     fun getFluidButtons(player: Player): MutableList<Pair<Item, String>> = PylonRegistry.FLUIDS.getKeys().filter {
         !PylonGuide.hiddenFluids.contains(it)
-    }.map {
+    }.mapNotNull {
         val translator = AddonTranslator.translators[getAddon(it)]!!
         val name = translator.translate(
             Component.translatable("pylon.${it.namespace}.fluid.${it.key}"), player.locale()
         )
-        check(name != null)
-        val plainTextName = serializer.serialize(name).lowercase()
-        Pair(FluidButton(it), plainTextName)
+        if (name == null) {
+            null
+        } else {
+            val plainTextName = serializer.serialize(name).lowercase()
+            Pair(FluidButton(it), plainTextName)
+        }
     }.toMutableList()
 
     override fun getItemNamePairs(player: Player, search: String): List<Pair<Item, String>> {

--- a/pylon-test/src/main/java/io/github/pylonmc/pylon/test/block/TestPylonSimpleMultiblock.java
+++ b/pylon-test/src/main/java/io/github/pylonmc/pylon/test/block/TestPylonSimpleMultiblock.java
@@ -28,10 +28,10 @@ public class TestPylonSimpleMultiblock extends PylonBlock implements PylonSimple
     }
 
     @Override
-    public @NotNull Map<Vector3i, Component> getComponents() {
+    public @NotNull Map<Vector3i, MultiblockComponent> getComponents() {
         return Map.of(
-                new Vector3i(1, 1, 4), new PylonComponent(Blocks.SIMPLE_BLOCK_KEY),
-                new Vector3i(2, -1, 0), new PylonComponent(Blocks.SIMPLE_BLOCK_KEY)
+                new Vector3i(1, 1, 4), new PylonMultiblockComponent(Blocks.SIMPLE_BLOCK_KEY),
+                new Vector3i(2, -1, 0), new PylonMultiblockComponent(Blocks.SIMPLE_BLOCK_KEY)
         );
     }
 }


### PR DESCRIPTION
Just a few small fixes I made while working on hydraulic machines
- fixed pylon guide search feature breaking if any item/fluid does not have a valid name
- fix not being able to sneak to place block on a PylonGuiBlock (I am not sure if my changes will break something - @Seggan if you could have a look that would be good)
- renamed Component to MultiblockComponent
- added getItem method to config section which will get a pylon item or a material