### PR TITLE
Use new interface with FluidOrItem instead of RecipeChoice

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/guide/button/FluidButton.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/guide/button/FluidButton.kt
@@ -26,7 +26,7 @@ open class FluidButton(val key: NamespacedKey, val amount: Double?) : AbstractIt
             .name(Component.translatable(
                 "pylon.pyloncore.guide.button.fluid.name",
                 PylonArgument.of("fluid", fluid.getItem().stack.getData(DataComponentTypes.ITEM_NAME)!!),
-                PylonArgument.of("amount", UnitFormat.MILLIBUCKETS.format(amount))
+                PylonArgument.of("amount", UnitFormat.MILLIBUCKETS.format(amount).decimalPlaces(2))
             ))
     }
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/research/Research.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/research/Research.kt
@@ -9,6 +9,7 @@ import io.github.pylonmc.pylon.core.event.PrePylonCraftEvent
 import io.github.pylonmc.pylon.core.i18n.PylonArgument
 import io.github.pylonmc.pylon.core.item.PylonItem
 import io.github.pylonmc.pylon.core.item.research.Research.Companion.canPickUp
+import io.github.pylonmc.pylon.core.recipe.FluidOrItem
 import io.github.pylonmc.pylon.core.recipe.RecipeType
 import io.github.pylonmc.pylon.core.registry.PylonRegistry
 import io.github.pylonmc.pylon.core.util.persistentData
@@ -195,9 +196,14 @@ data class Research(
                 return
             }
 
-            val canCraft = event.recipe.outputItems.all {
-                val item = PylonItem.fromStack(it)
-                item == null || event.player.canCraft(item, true)
+            val canCraft = event.recipe.results.all {
+                when (it) {
+                    is FluidOrItem.Item ->  {
+                        val item = PylonItem.fromStack(it.item)
+                        item == null || event.player.canCraft(item, true)
+                    }
+                    else -> true
+                }
             }
 
             if (!canCraft) {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/FluidOrItem.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/FluidOrItem.kt
@@ -1,0 +1,31 @@
+package io.github.pylonmc.pylon.core.recipe
+
+import io.github.pylonmc.pylon.core.fluid.PylonFluid
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.RecipeChoice
+
+sealed interface FluidOrItem {
+
+    @JvmRecord
+    data class Item(val item: ItemStack) : FluidOrItem
+
+    @JvmRecord
+    data class Fluid(val fluid: PylonFluid, val amountMillibuckets: Double) : FluidOrItem
+
+    companion object {
+
+        @JvmStatic
+        fun of(item: ItemStack) = Item(item)
+
+        @JvmStatic
+        fun of(fluid: PylonFluid, amountMillibuckets: Double) = Fluid(fluid, amountMillibuckets)
+
+        @JvmStatic
+        fun of(choice: RecipeChoice): List<FluidOrItem>
+            = when (choice) {
+                is RecipeChoice.ExactChoice -> listOf(of(choice.itemStack))
+                is RecipeChoice.MaterialChoice -> choice.choices.map { of(ItemStack(it)) }
+                else -> emptyList()
+            }
+    }
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/PylonRecipe.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/PylonRecipe.kt
@@ -1,11 +1,9 @@
 package io.github.pylonmc.pylon.core.recipe
 
 import io.github.pylonmc.pylon.core.fluid.PylonFluid
-import io.github.pylonmc.pylon.core.item.PylonItem
 import io.github.pylonmc.pylon.core.util.isPylonSimilar
 import org.bukkit.Keyed
 import org.bukkit.inventory.ItemStack
-import org.bukkit.inventory.RecipeChoice
 import xyz.xenondevs.invui.gui.Gui
 
 interface PylonRecipe : Keyed {
@@ -13,20 +11,36 @@ interface PylonRecipe : Keyed {
     val isHidden: Boolean
         get() = false
 
-    val inputItems: List<RecipeChoice>
-    val inputFluids: List<PylonFluid> get() = emptyList()
-    val outputItems: List<ItemStack>
-    val outputFluids: List<PylonFluid> get() = emptyList()
+    val inputs: List<FluidOrItem>
+    val results: List<FluidOrItem>
 
-    fun isInput(stack: ItemStack) = inputItems.any {
-        if (it is RecipeChoice.MaterialChoice && PylonItem.fromStack(stack) != null) {
-            return false
+    fun isInput(stack: ItemStack) = inputs.any {
+        when (it) {
+            is FluidOrItem.Item -> it.item.isPylonSimilar(stack)
+            else -> false
         }
-        @Suppress("SENSELESS_COMPARISON") // I have found it's very easy to return null input item by accident, hence the seemingly redundant null check
-        it != null && it.test(stack)
     }
-    fun isInput(fluid: PylonFluid) = fluid in inputFluids
-    fun isOutput(stack: ItemStack) = outputItems.any { stack.isPylonSimilar(it) }
-    fun isOutput(fluid: PylonFluid) = fluid in outputFluids
+
+    fun isInput(fluid: PylonFluid) = inputs.any {
+        when (it) {
+            is FluidOrItem.Fluid -> it.fluid == fluid
+            else -> false
+        }
+    }
+
+    fun isOutput(stack: ItemStack) = results.any {
+        when (it) {
+            is FluidOrItem.Item -> it.item.isPylonSimilar(stack)
+            else -> false
+        }
+    }
+
+    fun isOutput(fluid: PylonFluid) = results.any {
+        when (it) {
+            is FluidOrItem.Fluid -> it.fluid == fluid
+            else -> false
+        }
+    }
+
     fun display(): Gui
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/vanilla/Cooking.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/vanilla/Cooking.kt
@@ -3,6 +3,7 @@ package io.github.pylonmc.pylon.core.recipe.vanilla
 import io.github.pylonmc.pylon.core.guide.button.ItemButton
 import io.github.pylonmc.pylon.core.i18n.PylonArgument
 import io.github.pylonmc.pylon.core.item.builder.ItemStackBuilder
+import io.github.pylonmc.pylon.core.recipe.FluidOrItem
 import io.github.pylonmc.pylon.core.util.gui.GuiItems
 import io.github.pylonmc.pylon.core.util.gui.unit.UnitFormat
 import net.kyori.adventure.text.Component
@@ -13,9 +14,9 @@ import xyz.xenondevs.invui.gui.AbstractGui
 import xyz.xenondevs.invui.gui.Gui
 
 
-abstract class CookingRecipeWrapper(override val recipe: CookingRecipe<*>) : VanillaRecipeWrapper {
-    override val inputItems: List<RecipeChoice> = listOf(recipe.inputChoice)
-    override val outputItems: List<ItemStack> = listOf(recipe.result)
+abstract class CookingRecipeWrapper(final override val recipe: CookingRecipe<*>) : VanillaRecipeWrapper {
+    override val inputs: List<FluidOrItem> = FluidOrItem.of(recipe.inputChoice)
+    override val results: List<FluidOrItem> = listOf(FluidOrItem.of(recipe.result))
     override fun getKey(): NamespacedKey = recipe.key
 }
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/vanilla/Crafting.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/vanilla/Crafting.kt
@@ -16,9 +16,7 @@ abstract class CraftingRecipeWrapper(val craftingRecipe: CraftingRecipe) : Vanil
 }
 
 class ShapedRecipeWrapper(override val recipe: ShapedRecipe) : CraftingRecipeWrapper(recipe) {
-    override val inputs: List<FluidOrItem> = recipe.choiceMap.values.filterNotNull().flatMap {
-        FluidOrItem.of(it)
-    }.toList()
+    override val inputs: List<FluidOrItem> = recipe.choiceMap.values.filterNotNull().flatMap(FluidOrItem::of)
 
     override fun display(): Gui {
         val gui = Gui.normal()
@@ -36,8 +34,8 @@ class ShapedRecipeWrapper(override val recipe: ShapedRecipe) : CraftingRecipeWra
 
         val height = recipe.shape.size
         val width = recipe.shape[0].length
-        for (x in 0..<width) {
-            for (y in 0..<height) {
+        for (x in 0 until width) {
+            for (y in 0 until height) {
                 gui.setItem(12 + x + 9 * y, getDisplaySlot(recipe, x, y))
             }
         }
@@ -52,9 +50,7 @@ class ShapedRecipeWrapper(override val recipe: ShapedRecipe) : CraftingRecipeWra
 }
 
 class ShapelessRecipeWrapper(override val recipe: ShapelessRecipe) : CraftingRecipeWrapper(recipe) {
-    override val inputs: List<FluidOrItem> = recipe.choiceList.filterNotNull().flatMap {
-        FluidOrItem.of(it)
-    }.toList()
+    override val inputs: List<FluidOrItem> = recipe.choiceList.filterNotNull().flatMap(FluidOrItem::of)
 
     override fun display() = Gui.normal()
             .setStructure(

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/vanilla/Crafting.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/vanilla/Crafting.kt
@@ -1,6 +1,7 @@
 package io.github.pylonmc.pylon.core.recipe.vanilla
 
 import io.github.pylonmc.pylon.core.guide.button.ItemButton
+import io.github.pylonmc.pylon.core.recipe.FluidOrItem
 import io.github.pylonmc.pylon.core.util.gui.GuiItems
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
@@ -11,11 +12,14 @@ import xyz.xenondevs.invui.item.Item
 
 abstract class CraftingRecipeWrapper(val craftingRecipe: CraftingRecipe) : VanillaRecipeWrapper {
     override fun getKey(): NamespacedKey = craftingRecipe.key
-    override val outputItems: List<ItemStack> = listOf(craftingRecipe.result)
+    override val results: List<FluidOrItem> = listOf(FluidOrItem.of(craftingRecipe.result))
 }
 
 class ShapedRecipeWrapper(override val recipe: ShapedRecipe) : CraftingRecipeWrapper(recipe) {
-    override val inputItems: List<RecipeChoice> = recipe.choiceMap.values.filter { it != null }.toList()
+    override val inputs: List<FluidOrItem> = recipe.choiceMap.values.filterNotNull().flatMap {
+        FluidOrItem.of(it)
+    }.toList()
+
     override fun display(): Gui {
         val gui = Gui.normal()
             .setStructure(
@@ -32,8 +36,8 @@ class ShapedRecipeWrapper(override val recipe: ShapedRecipe) : CraftingRecipeWra
 
         val height = recipe.shape.size
         val width = recipe.shape[0].length
-        for (x in 0..width-1) {
-            for (y in 0..height-1) {
+        for (x in 0..<width) {
+            for (y in 0..<height) {
                 gui.setItem(12 + x + 9 * y, getDisplaySlot(recipe, x, y))
             }
         }
@@ -48,7 +52,10 @@ class ShapedRecipeWrapper(override val recipe: ShapedRecipe) : CraftingRecipeWra
 }
 
 class ShapelessRecipeWrapper(override val recipe: ShapelessRecipe) : CraftingRecipeWrapper(recipe) {
-    override val inputItems: List<RecipeChoice> = recipe.choiceList.filter { it != null }
+    override val inputs: List<FluidOrItem> = recipe.choiceList.filterNotNull().flatMap {
+        FluidOrItem.of(it)
+    }.toList()
+
     override fun display() = Gui.normal()
             .setStructure(
                 "# # # # # # # # #",

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/vanilla/Smithing.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/vanilla/Smithing.kt
@@ -1,12 +1,12 @@
 package io.github.pylonmc.pylon.core.recipe.vanilla
 
 import io.github.pylonmc.pylon.core.guide.button.ItemButton
+import io.github.pylonmc.pylon.core.recipe.FluidOrItem
 import io.github.pylonmc.pylon.core.util.gui.GuiItems
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.Recipe
-import org.bukkit.inventory.RecipeChoice
 import org.bukkit.inventory.SmithingRecipe
 import xyz.xenondevs.invui.gui.Gui
 
@@ -14,8 +14,8 @@ import xyz.xenondevs.invui.gui.Gui
 class SmithingRecipeWrapper(val smithingRecipe: SmithingRecipe) : VanillaRecipeWrapper {
 
     override val recipe: Recipe = smithingRecipe
-    override val inputItems: List<RecipeChoice> = listOf(smithingRecipe.base, smithingRecipe.addition)
-    override val outputItems: List<ItemStack> = listOf(smithingRecipe.result)
+    override val inputs: List<FluidOrItem> = FluidOrItem.of(smithingRecipe.base) + FluidOrItem.of(smithingRecipe.addition)
+    override val results: List<FluidOrItem> = listOf(FluidOrItem.of(smithingRecipe.result))
 
     override fun display() = Gui.normal()
         .setStructure(


### PR DESCRIPTION
- Adds a new FluidOrItem interface to simplify recipe logic
- Replaces the 4 `inputItems`, `inputFluids`, `outputItems`, `outputFluids` with `inputs` and `outputs` using the new interface

closes https://github.com/pylonmc/pylon-core/issues/167