### PR TITLE
Replace createEntities with addEntity

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonEntityHolderBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonEntityHolderBlock.kt
@@ -1,11 +1,9 @@
 package io.github.pylonmc.pylon.core.block.base
 
-import io.github.pylonmc.pylon.core.block.context.BlockCreateContext
 import io.github.pylonmc.pylon.core.datatypes.PylonSerializers
 import io.github.pylonmc.pylon.core.entity.EntityStorage
 import io.github.pylonmc.pylon.core.entity.PylonEntity
 import io.github.pylonmc.pylon.core.event.PylonBlockDeserializeEvent
-import io.github.pylonmc.pylon.core.event.PylonBlockPlaceEvent
 import io.github.pylonmc.pylon.core.event.PylonBlockSerializeEvent
 import io.github.pylonmc.pylon.core.event.PylonBlockUnloadEvent
 import io.github.pylonmc.pylon.core.util.pylonKey
@@ -13,8 +11,7 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.annotations.MustBeInvokedByOverriders
-import java.util.IdentityHashMap
-import java.util.UUID
+import java.util.*
 
 /**
  * A block that has one or more associated Pylon entities. For example, a pedestal that
@@ -25,11 +22,16 @@ import java.util.UUID
  */
 interface PylonEntityHolderBlock : PylonBreakHandler {
 
-    fun createEntities(context: BlockCreateContext): Map<String, PylonEntity<*>> = mutableMapOf()
-
     @get:ApiStatus.NonExtendable
     val heldEntities: MutableMap<String, UUID>
-        get() = holders[this] ?: error("You cannot access held entities before the block is placed")
+        get() = holders.getOrPut(this) { mutableMapOf() }
+
+    fun addEntity(name: String, entity: PylonEntity<*>) {
+        if (!EntityStorage.isPylonEntity(entity.uuid)) {
+            EntityStorage.add(entity)
+        }
+        heldEntities[name] = entity.uuid
+    }
 
     @ApiStatus.NonExtendable
     fun getHeldEntityUuid(name: String) = heldEntities[name] ?: throw IllegalArgumentException("Entity $name not found")
@@ -77,21 +79,6 @@ interface PylonEntityHolderBlock : PylonBreakHandler {
         private val entityType = PylonSerializers.MAP.mapTypeFrom(PylonSerializers.STRING, PylonSerializers.UUID)
 
         private val holders = IdentityHashMap<PylonEntityHolderBlock, MutableMap<String, UUID>>()
-
-        @EventHandler
-        private fun onPlace(event: PylonBlockPlaceEvent) {
-            val block = event.pylonBlock
-            if (block !is PylonEntityHolderBlock) return
-            val entities = mutableMapOf<String, UUID>()
-            for ((name, entity) in block.createEntities(event.context)) {
-                val uuid = entity.uuid
-                if (!EntityStorage.isPylonEntity(uuid)) {
-                    EntityStorage.add(entity)
-                }
-                entities[name] = uuid
-            }
-            holders[block] = entities
-        }
 
         @EventHandler
         private fun onDeserialize(event: PylonBlockDeserializeEvent) {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/content/fluid/FluidPipeConnector.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/content/fluid/FluidPipeConnector.kt
@@ -18,15 +18,12 @@ import org.bukkit.persistence.PersistentDataContainer
 class FluidPipeConnector : PylonBlock, PylonEntityHolderBlock {
 
     @Suppress("unused")
-    constructor(block: Block, context: BlockCreateContext) : super(block)
+    constructor(block: Block, context: BlockCreateContext) : super(block) {
+        addEntity("connector", FluidPointInteraction.make(context, FluidPointType.CONNECTOR))
+    }
 
     @Suppress("unused")
     constructor(block: Block, pdc: PersistentDataContainer) : super(block)
-
-    override fun createEntities(context: BlockCreateContext)
-        = mutableMapOf(
-            "connector" to FluidPointInteraction.make(context, FluidPointType.CONNECTOR)
-        )
 
     val fluidPointInteraction
         get() = getHeldEntityOrThrow(FluidPointInteraction::class.java, "connector")


### PR DESCRIPTION
Removes `createEntities` and replaces it with `addEntity` which can be called in the constructor.

This is nice because is removes some boilerplate, helps make sure anything related to creating the block is done in the place constructor, and allows entities to be accessed from the place constructor.

See https://github.com/pylonmc/pylon-base/pull/104