### PR TITLE
Replace get methods with setters and persistent data for block tickers

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/PylonCore.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/PylonCore.kt
@@ -69,6 +69,7 @@ object PylonCore : JavaPlugin(), PylonAddon {
         Bukkit.getPluginManager().registerEvents(PylonFluidTank, this)
         Bukkit.getPluginManager().registerEvents(PylonRecipeListener, this)
         Bukkit.getPluginManager().registerEvents(ConnectingService, this)
+        Bukkit.getPluginManager().registerEvents(PylonTickingBlock, this)
 
         Bukkit.getScheduler().runTaskTimer(
             this,

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/TickManager.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/TickManager.kt
@@ -60,7 +60,7 @@ object TickManager : Listener {
         if (pylonBlock is PylonTickingBlock) {
             val dispatcher =
                 if (pylonBlock.isAsync) PylonCore.asyncDispatcher else PylonCore.minecraftDispatcher
-            val tickDelay = pylonBlock.getCustomTickRate(PylonConfig.tickRate)
+            val tickDelay = pylonBlock.tickInterval
             tickingBlocks[pylonBlock] = PylonCore.launch(dispatcher) {
                 var errors = 0
                 var lastTickNanos = System.nanoTime()

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonFluidTank.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonFluidTank.kt
@@ -165,7 +165,6 @@ interface PylonFluidTank : PylonFluidBlock {
     companion object : Listener {
 
         private val fluidTankKey = pylonKey("fluid_tank_data")
-        private val fluidTankDatatype = PylonSerializers.FLUID_TANK_DATA
 
         private val fluidTankBlocks = IdentityHashMap<PylonFluidTank, FluidTankData>()
 
@@ -173,7 +172,7 @@ interface PylonFluidTank : PylonFluidBlock {
         private fun onDeserialize(event: PylonBlockDeserializeEvent) {
             val block = event.pylonBlock
             if (block is PylonFluidTank) {
-                fluidTankBlocks[block] = event.pdc.get(fluidTankKey, fluidTankDatatype)
+                fluidTankBlocks[block] = event.pdc.get(fluidTankKey, PylonSerializers.FLUID_TANK_DATA)
                     ?: error("Fluid tank data not found for ${block.key}")
             }
         }
@@ -182,7 +181,7 @@ interface PylonFluidTank : PylonFluidBlock {
         private fun onSerialize(event: PylonBlockSerializeEvent) {
             val block = event.pylonBlock
             if (block is PylonFluidTank) {
-                event.pdc.set(fluidTankKey, fluidTankDatatype, fluidTankBlocks[block]!!)
+                event.pdc.set(fluidTankKey, PylonSerializers.FLUID_TANK_DATA, fluidTankBlocks[block]!!)
             }
         }
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonSimpleMultiblock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonSimpleMultiblock.kt
@@ -239,7 +239,7 @@ interface PylonSimpleMultiblock : PylonMultiblock, PylonEntityHolderBlock {
 
     companion object : Listener {
 
-        private val simpleMultiblockKey = pylonKey("fluid_tank_data")
+        private val simpleMultiblockKey = pylonKey("simple_multiblock_data")
 
         private val simpleMultiblocks = IdentityHashMap<PylonSimpleMultiblock, SimpleMultiblockData>()
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonTickingBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonTickingBlock.kt
@@ -30,6 +30,12 @@ interface PylonTickingBlock {
         tickingData.tickInterval = tickInterval
     }
 
+    /**
+     * WARNING: Settings a block to tick asynchronously could have unintended consequences.
+     *
+     * Only set this option if you understand what 'asynchronous' means, and note that you
+     * cannot interact with the world asynchronously.
+     */
     fun setAsync(isAsync: Boolean) {
         tickingData.isAsync = isAsync
     }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonTickingBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonTickingBlock.kt
@@ -1,11 +1,76 @@
 package io.github.pylonmc.pylon.core.block.base
 
+import io.github.pylonmc.pylon.core.config.PylonConfig
+import io.github.pylonmc.pylon.core.datatypes.PylonSerializers
+import io.github.pylonmc.pylon.core.event.PylonBlockDeserializeEvent
+import io.github.pylonmc.pylon.core.event.PylonBlockSerializeEvent
+import io.github.pylonmc.pylon.core.event.PylonBlockUnloadEvent
+import io.github.pylonmc.pylon.core.util.pylonKey
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.jetbrains.annotations.ApiStatus
+import java.util.*
+
 interface PylonTickingBlock {
 
-    val isAsync: Boolean
-        get() = false
+    @get:ApiStatus.NonExtendable
+    val tickingData: TickingBlockData
+        get() = tickingBlocks.getOrPut(this) { TickingBlockData(
+            PylonConfig.defaultTickInterval,
+            false
+        )}
 
-    fun getCustomTickRate(globalTickRate: Int): Int = globalTickRate
+    val tickInterval
+        get() = tickingData.tickInterval
+
+    val isAsync
+        get() = tickingData.isAsync
+
+    fun setTickInterval(tickInterval: Int) {
+        tickingData.tickInterval = tickInterval
+    }
+
+    fun setAsync(isAsync: Boolean) {
+        tickingData.isAsync = isAsync
+    }
 
     fun tick(deltaSeconds: Double)
+
+    @ApiStatus.Internal
+    data class TickingBlockData(
+        var tickInterval: Int,
+        var isAsync: Boolean,
+    )
+
+    companion object : Listener {
+
+        private val tickingBlockKey = pylonKey("ticking_block_data")
+
+        private val tickingBlocks = IdentityHashMap<PylonTickingBlock, TickingBlockData>()
+
+        @EventHandler
+        private fun onDeserialize(event: PylonBlockDeserializeEvent) {
+            val block = event.pylonBlock
+            if (block is PylonTickingBlock) {
+                tickingBlocks[block] = event.pdc.get(tickingBlockKey, PylonSerializers.TICKING_BLOCK_DATA)
+                    ?: error("Ticking block data not found for ${block.key}")
+            }
+        }
+
+        @EventHandler
+        private fun onSerialize(event: PylonBlockSerializeEvent) {
+            val block = event.pylonBlock
+            if (block is PylonTickingBlock) {
+                event.pdc.set(tickingBlockKey, PylonSerializers.TICKING_BLOCK_DATA, tickingBlocks[block]!!)
+            }
+        }
+
+        @EventHandler
+        private fun onUnload(event: PylonBlockUnloadEvent) {
+            val block = event.pylonBlock
+            if (block is PylonTickingBlock) {
+                tickingBlocks.remove(block)
+            }
+        }
+    }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/waila/Waila.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/waila/Waila.kt
@@ -100,7 +100,7 @@ class Waila private constructor(private val player: Player, private val job: Job
                 val waila = wailas[player.uniqueId]!!
                 while (true) {
                     waila.updateDisplay()
-                    delay(PylonConfig.wailaIntervalTicks.ticks)
+                    delay(PylonConfig.wailaTickInterval.ticks)
                 }
             })
         }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/PylonConfig.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/PylonConfig.kt
@@ -8,16 +8,16 @@ object PylonConfig {
     private val config = Config(PylonCore, "config.yml")
 
     @JvmStatic
-    val tickRate: Int by config
+    val defaultTickInterval: Int by config
 
     @JvmStatic
     val allowedBlockErrors: Int by config
 
     @JvmStatic
-    val wailaIntervalTicks: Int by config
+    val wailaTickInterval: Int by config
 
     @JvmStatic
-    val fluidIntervalTicks: Int by config
+    val fluidTickInterval: Int by config
 
     @JvmStatic
     val blockDataAutosaveIntervalSeconds: Long = config.getOrThrow<Int>("block-data-autosave-interval-seconds").toLong()
@@ -28,7 +28,7 @@ object PylonConfig {
     @JvmStatic
     val researchesEnabled: Boolean = config.getOrThrow("research.enabled")
 
-    val PIPE_PLACEMENT_TASK_INTERVAL_TICKS: Long = config.getOrThrow<Int>("pipe-placement.task-interval-ticks").toLong()
+    val PIPE_PLACEMENT_TASK_INTERVAL_TICKS: Long = config.getOrThrow<Int>("pipe-placement.tick-interval").toLong()
 
     val PIPE_PLACEMENT_MAX_DISTANCE: Long = config.getOrThrow<Int>("pipe-placement.max-distance").toLong()
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/datatypes/PylonSerializers.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/datatypes/PylonSerializers.kt
@@ -110,6 +110,9 @@ object PylonSerializers {
     @JvmSynthetic
     internal val SIMPLE_MULTIBLOCK_DATA = SimpleMultiblockDataPersistentDataType
 
+    @JvmSynthetic
+    internal val TICKING_BLOCK_DATA = TickingBlockPersistentDataType
+
     @JvmField
     val FLUID_CONNECTION_POINT = FluidConnectionPointDataType
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/datatypes/TickingBlockPersistentDataType.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/datatypes/TickingBlockPersistentDataType.kt
@@ -1,0 +1,35 @@
+package io.github.pylonmc.pylon.core.datatypes
+
+import io.github.pylonmc.pylon.core.block.base.PylonTickingBlock
+import io.github.pylonmc.pylon.core.util.pylonKey
+import org.bukkit.persistence.PersistentDataAdapterContext
+import org.bukkit.persistence.PersistentDataContainer
+import org.bukkit.persistence.PersistentDataType
+
+object TickingBlockPersistentDataType : PersistentDataType<PersistentDataContainer, PylonTickingBlock.TickingBlockData> {
+    val tickIntervalKey = pylonKey("tick_interval")
+    val isAsyncKey = pylonKey("is_async")
+
+    override fun getPrimitiveType(): Class<PersistentDataContainer> = PersistentDataContainer::class.java
+
+    override fun getComplexType(): Class<PylonTickingBlock.TickingBlockData> = PylonTickingBlock.TickingBlockData::class.java
+
+    override fun fromPrimitive(
+        primitive: PersistentDataContainer,
+        context: PersistentDataAdapterContext
+    ): PylonTickingBlock.TickingBlockData {
+        val tickInterval = primitive.get(tickIntervalKey, PersistentDataType.INTEGER)!!
+        val isAsync = primitive.get(isAsyncKey, PersistentDataType.BOOLEAN)!!
+        return PylonTickingBlock.TickingBlockData(tickInterval, isAsync)
+    }
+
+    override fun toPrimitive(
+        complex: PylonTickingBlock.TickingBlockData,
+        context: PersistentDataAdapterContext
+    ): PersistentDataContainer {
+        val pdc = context.newPersistentDataContainer()
+        pdc.set(tickIntervalKey, PersistentDataType.INTEGER, complex.tickInterval)
+        pdc.set(isAsyncKey, PersistentDataType.BOOLEAN, complex.isAsync)
+        return pdc
+    }
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidManager.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/fluid/FluidManager.kt
@@ -424,7 +424,7 @@ object FluidManager {
         tickers[segment] = PylonCore.launch {
             var lastTickNanos = System.nanoTime()
             while (true) {
-                delay(PylonConfig.fluidIntervalTicks.ticks)
+                delay(PylonConfig.fluidTickInterval.ticks)
                 val dt = (System.nanoTime() - lastTickNanos) / 1.0e9
                 lastTickNanos = System.nanoTime()
                 tick(segment, dt)

--- a/pylon-core/src/main/resources/config.yml
+++ b/pylon-core/src/main/resources/config.yml
@@ -1,26 +1,28 @@
-# The amount of Minecraft ticks between each Pylon tick
-tick-rate: 1
+# The default interval (in Minecraft ticks) between each block tick
+# Most blocks have a custom tick interval which can be changed in their settings
+default-tick-interval: 20
 
 # The number of errors a ticking block can throw before it is disabled
 allowed-block-errors: 5
 
-# The interval, in ticks, between WAILA checks
-waila-interval-ticks: 1
+# The interval (in Minecraft ticks), between WAILA checks
+waila-tick-interval: 1
 
-# The interval between fluid network ticks
-fluid-interval-ticks: 1
+# The interval (in Minecraft ticks) between fluid network ticks
+fluid-tick-interval: 5
 
-block-data-autosave-interval-seconds: 3
+block-data-autosave-interval-seconds: 60
 
-entity-data-autosave-interval-seconds: 3
+entity-data-autosave-interval-seconds: 60
 
 research:
   enabled: true
-  # The interval, in ticks, between when Pylon checks for unresearched items in inventories
-  interval: 20
+  # The interval (in Minecraft ticks) between when Pylon checks for unresearched items in inventories
+  tick-interval: 20
 
 pipe-placement:
-  task-interval-ticks: 1
+  # The interval (in Minecraft ticks) between pipe placement task ticks
+  tick-interval: 1
 
   # Recommended to keep this low to make pipe placement easier
   # Might break pipe placement if set very high due to chunkloading mechanics


### PR DESCRIPTION
- Replace isAsync and getCustomTickRate with setAsync and setTickRate
- Fix SimpleMultiblock storing data under fluid_tank_data key
- Standardise ticking settings to tick-interval (we were using several different names for this previously)