### PR TITLE
Add virtual recipe

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/content/guide/PylonGuide.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/content/guide/PylonGuide.kt
@@ -10,6 +10,7 @@ import io.github.pylonmc.pylon.core.guide.pages.research.ResearchesPage
 import io.github.pylonmc.pylon.core.item.PylonItem
 import io.github.pylonmc.pylon.core.item.base.PylonInteractor
 import io.github.pylonmc.pylon.core.item.builder.ItemStackBuilder
+import io.github.pylonmc.pylon.core.recipe.PylonVirtualRecipe
 import io.github.pylonmc.pylon.core.util.pylonKey
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
@@ -78,6 +79,9 @@ class PylonGuide(stack: ItemStack) : PylonItem(stack), PylonInteractor {
         @JvmStatic
         var settingsAndInfoPage = SettingsAndInfoPage()
 
+        @JvmStatic
+        val virtualRecipes: MutableMap<NamespacedKey, PylonVirtualRecipe> = mutableMapOf()
+
         /**
          * Hide an item from showing up in searches
          */
@@ -97,6 +101,13 @@ class PylonGuide(stack: ItemStack) : PylonItem(stack), PylonInteractor {
          */
         fun hideResearch(key: NamespacedKey) {
             hiddenResearches.add(key)
+        }
+
+        /**
+         * Adds a virtual recipe for display
+         */
+        fun addVirtualRecipe(recipe: PylonVirtualRecipe) {
+            virtualRecipes[recipe.key] = recipe
         }
 
         /**

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/guide/pages/fluid/FluidRecipesPage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/guide/pages/fluid/FluidRecipesPage.kt
@@ -20,6 +20,11 @@ open class FluidRecipesPage(fluidKey: NamespacedKey) : GuidePage {
     val pages: MutableList<Gui> = mutableListOf()
 
     init {
+        for (recipe in PylonGuide.virtualRecipes.values) {
+            if (recipe.isOutput(fluid)) {
+                pages.add(recipe.display())
+            }
+        }
         for (type in PylonRegistry.RECIPE_TYPES) {
             for (recipe in type.recipes) {
                 if (!recipe.isHidden && recipe.isOutput(fluid)) {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/guide/pages/fluid/FluidUsagesPage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/guide/pages/fluid/FluidUsagesPage.kt
@@ -20,6 +20,11 @@ open class FluidUsagesPage(fluidKey: NamespacedKey) : GuidePage {
     val pages: MutableList<Gui> = mutableListOf()
 
     init {
+        for (recipe in PylonGuide.virtualRecipes.values) {
+            if (recipe.isInput(fluid)) {
+                pages.add(recipe.display())
+            }
+        }
         for (type in PylonRegistry.RECIPE_TYPES) {
             for (recipe in type.recipes) {
                 if (!recipe.isHidden && recipe.isInput(fluid)) {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/guide/pages/item/ItemRecipesPage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/guide/pages/item/ItemRecipesPage.kt
@@ -20,6 +20,11 @@ open class ItemRecipesPage(val stack: ItemStack) : GuidePage {
     val pages: MutableList<Gui> = mutableListOf()
 
     init {
+        for (recipe in PylonGuide.virtualRecipes.values) {
+            if (recipe.isInput(stack)) {
+                pages.add(recipe.display())
+            }
+        }
         for (type in PylonRegistry.RECIPE_TYPES) {
             for (recipe in type.recipes) {
                 if (!recipe.isHidden && recipe.isOutput(stack)) {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/guide/pages/item/ItemUsagesPage.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/guide/pages/item/ItemUsagesPage.kt
@@ -20,6 +20,11 @@ open class ItemUsagesPage(val stack: ItemStack) : GuidePage {
     val pages: MutableList<Gui> = mutableListOf()
 
     init {
+        for (recipe in PylonGuide.virtualRecipes.values) {
+            if (recipe.isOutput(stack)) {
+                pages.add(recipe.display())
+            }
+        }
         for (type in PylonRegistry.RECIPE_TYPES) {
             for (recipe in type.recipes) {
                 if (!recipe.isHidden && recipe.isInput(stack)) {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/PylonVirtualRecipe.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/PylonVirtualRecipe.kt
@@ -1,0 +1,23 @@
+package io.github.pylonmc.pylon.core.recipe
+
+import io.github.pylonmc.pylon.core.fluid.PylonFluid
+import org.bukkit.Keyed
+import org.bukkit.inventory.ItemStack
+import xyz.xenondevs.invui.gui.Gui
+
+/**
+ * A sort of "pseudo recipe" that does not correspond to any real recipe, but is used for displaying
+ * stuff in the guide. For example, the water pump uses a `PylonVirtualRecipe` to display the
+ * output of the pump in the guide, even though it's not a "recipe" per se.
+ *
+ * @see [io.github.pylonmc.pylon.core.content.guide.PylonGuide.addVirtualRecipe]
+ */
+interface PylonVirtualRecipe : Keyed {
+
+    fun isInput(stack: ItemStack): Boolean
+    fun isInput(fluid: PylonFluid): Boolean
+    fun isOutput(stack: ItemStack): Boolean
+    fun isOutput(fluid: PylonFluid): Boolean
+
+    fun display(): Gui
+}


### PR DESCRIPTION
Went for a slightly different model than the original planned `DisplayRecipeType`, this version just separates it from the recipe infrastructure completely. Having though over both possibilities, I think it's much cleaner.

Closes #150 