### PR TITLE
fix runSnapshotServer gradle task

### DIFF
--- a/pylon-core/gradle.properties
+++ b/pylon-core/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
-version=-SNAPSHOT
+version=SNAPSHOT
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true


### PR DESCRIPTION
core jar was getting named pylon-core--SNAPSHOT.jar while the runServer action looked for the pylon-core-SNAPSHOT.jar file so it wouldn't copy it and base would fail to load