### PR TITLE
Fix pylon items being craftable for vanilla recipes

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItemListener.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/PylonItemListener.kt
@@ -249,8 +249,6 @@ internal object PylonItemListener : Listener {
             } catch (e: Exception) {
                 logEventHandleErr(event, e, pylonItem)
             }
-        } else {
-            event.isCancelled = true
         }
     }
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/base/VanillaCookingItem.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/base/VanillaCookingItem.kt
@@ -1,0 +1,3 @@
+package io.github.pylonmc.pylon.core.item.base
+
+interface VanillaCookingItem

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/base/VanillaSmithingMineral.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/base/VanillaSmithingMineral.kt
@@ -1,0 +1,3 @@
+package io.github.pylonmc.pylon.core.item.base
+
+interface VanillaSmithingMineral

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/RecipeListener.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/recipe/RecipeListener.kt
@@ -5,6 +5,7 @@ import io.github.pylonmc.pylon.core.item.base.*
 import io.github.pylonmc.pylon.core.item.research.Research.Companion.canCraft
 import io.github.pylonmc.pylon.core.util.isPylonAndIsNot
 import org.bukkit.Keyed
+import org.bukkit.block.Furnace
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
@@ -47,6 +48,16 @@ internal object PylonRecipeListener : Listener {
     private fun onCook(e: BlockCookEvent) {
         e.recipe ?: return
         if (e.source.isPylonAndIsNot<VanillaCookingItem>() && e.recipe?.key?.namespace == "minecraft") {
+            e.isCancelled = true
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    private fun onFuelBurn(e: FurnaceBurnEvent){
+        if(e.fuel.isPylonAndIsNot<VanillaCookingFuel>()){
+            e.isCancelled = true
+        }
+        if((e.block.state as Furnace).inventory.smelting.isPylonAndIsNot<VanillaCookingItem>()){
             e.isCancelled = true
         }
     }


### PR DESCRIPTION
- [x] Fix pylon items being used to craft vanilla recipes in crafting table
- [x] Fix pylon items being smelted into vanilla items
- [x] Fix trying to smelt pylon items into vanilla items using fuel in furnace, smoker and blast furnace
Closes #257 
This pr makes the assumption that all "vanilla" recipes have the namespace of their keys as minecraft but I think that the game will continue to be named minecraft for the foreseeable future so this is probably a safe assumption