### PR TITLE
Drop items held in PylonGuiBlocks in creative

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonGuiBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonGuiBlock.kt
@@ -72,7 +72,6 @@ interface PylonGuiBlock : PylonBreakHandler, PylonInteractableBlock {
     override fun onBreak(drops: MutableList<ItemStack>, context: BlockBreakContext) {
         guiBlocks.remove(this)
         val invs = inventories.remove(this) ?: return
-        if (!context.normallyDrops) return
         for (inv in invs) {
             for (item in inv.unsafeItems) {
                 item?.let(drops::add)


### PR DESCRIPTION
Better mimicks vanilla behaviour(eg chests) which always drop their contained items when broken, even in creative
Closes https://github.com/pylonmc/pylon-base/issues/185
