### PR TITLE
Simpler Item Models/Textures

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/builder/ItemStackBuilder.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/builder/ItemStackBuilder.kt
@@ -139,6 +139,7 @@ open class ItemStackBuilder private constructor(val stack: ItemStack) : ItemProv
             return of(stack)
                 .editPdc { it.set(PylonItemSchema.pylonItemKeyKey, PylonSerializers.NAMESPACED_KEY, key) }
                 .let {
+                    //  Adds the pylon item key as the FIRST string in custom model data, but preserve any pre-existing data
                     val originalModelData = it.stack.getData(DataComponentTypes.CUSTOM_MODEL_DATA)
                     val modelData = CustomModelData.customModelData().addString(key.toString());
                     if (originalModelData != null) {

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/builder/ItemStackBuilder.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/builder/ItemStackBuilder.kt
@@ -8,6 +8,7 @@ import io.github.pylonmc.pylon.core.util.fromMiniMessage
 import io.papermc.paper.datacomponent.DataComponentBuilder
 import io.papermc.paper.datacomponent.DataComponentType
 import io.papermc.paper.datacomponent.DataComponentTypes
+import io.papermc.paper.datacomponent.item.CustomModelData
 import io.papermc.paper.datacomponent.item.ItemLore
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ComponentLike
@@ -125,6 +126,7 @@ open class ItemStackBuilder private constructor(val stack: ItemStack) : ItemProv
         fun pylonItem(material: Material, key: NamespacedKey): ItemStackBuilder {
             return of(material)
                 .editPdc { pdc -> pdc.set(PylonItemSchema.pylonItemKeyKey, PylonSerializers.NAMESPACED_KEY, key) }
+                .set(DataComponentTypes.CUSTOM_MODEL_DATA, CustomModelData.customModelData().addString(key.toString()))
                 .defaultTranslatableName(key)
                 .defaultTranslatableLore(key)
         }
@@ -136,6 +138,15 @@ open class ItemStackBuilder private constructor(val stack: ItemStack) : ItemProv
         fun pylonItem(stack: ItemStack, key: NamespacedKey): ItemStackBuilder {
             return of(stack)
                 .editPdc { it.set(PylonItemSchema.pylonItemKeyKey, PylonSerializers.NAMESPACED_KEY, key) }
+                .let {
+                    val originalModelData = it.stack.getData(DataComponentTypes.CUSTOM_MODEL_DATA)
+                    val modelData = CustomModelData.customModelData().addString(key.toString());
+                    if (originalModelData != null) {
+                        modelData.addStrings(originalModelData.strings()).addColors(originalModelData.colors())
+                            .addFloats(originalModelData.floats()).addFlags(originalModelData.flags())
+                    }
+                    it.set(DataComponentTypes.CUSTOM_MODEL_DATA, modelData)
+                }
                 .defaultTranslatableName(key)
                 .defaultTranslatableLore(key)
         }


### PR DESCRIPTION
Adds the pylon item ids to the custom model data strings when using item stack builder to allow using the select model type with custom_model_data, for MUCH simpler resource packs and no more crazy nesting, it also ensures they wont be broken by other public bukkit data values