### PR TITLE
Better Sound Configs

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/ConfigSection.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/ConfigSection.kt
@@ -35,17 +35,8 @@ open class ConfigSection(val internalSection: ConfigurationSection) {
     }
 
     fun getSection(key: String): ConfigSection? {
-        val cached = cache[key]
-        if (cached != null) {
-            if (cached !is ConfigSection) {
-                error("$key is not a config section")
-            }
-            return cached
-        }
-
         val newConfig = internalSection.getConfigurationSection(key) ?: return null
         val configSection = ConfigSection(newConfig)
-        cache[key] = configSection
         return configSection
     }
 

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/ConfigSection.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/ConfigSection.kt
@@ -16,6 +16,7 @@ import java.util.WeakHashMap
 open class ConfigSection(val internalSection: ConfigurationSection) {
 
     private val cache: MutableMap<String, Any?> = WeakHashMap()
+    private val sectionCache: MutableMap<String, ConfigSection> = WeakHashMap()
 
     /**
      * Returns all the keys in the section.
@@ -25,18 +26,25 @@ open class ConfigSection(val internalSection: ConfigurationSection) {
 
     /**
      * Gets all the values in the section that are themselves sections.
+     * @throws NullPointerException if any top level keys do not correspond to a section
      */
     fun getSections(): Set<ConfigSection> {
         val configSections: MutableSet<ConfigSection> = mutableSetOf()
         for (key in internalSection.getKeys(false)) {
-            configSections.add(ConfigSection(internalSection.getConfigurationSection(key)!!))
+            configSections.add(getSection(key)!!)
         }
         return configSections
     }
 
     fun getSection(key: String): ConfigSection? {
+        val cached = sectionCache[key]
+        if (cached != null) {
+            return cached
+        }
+
         val newConfig = internalSection.getConfigurationSection(key) ?: return null
         val configSection = ConfigSection(newConfig)
+        sectionCache[key] = configSection
         return configSection
     }
 
@@ -90,7 +98,7 @@ open class ConfigSection(val internalSection: ConfigurationSection) {
     }
 
     fun createSection(key: String): ConfigSection
-            = ConfigSection(internalSection.createSection(key))
+        = ConfigSection(internalSection.createSection(key)).also { sectionCache[key] = it }
 
     /**
      * 'Merges' [other] with this ConfigSection by copying all of its keys into this ConfigSection.

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/PylonConfig.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/PylonConfig.kt
@@ -47,6 +47,9 @@ object PylonConfig {
     val researchMaxConfettiAmount = config.get("research.confetti.max-amount", ConfigAdapter.INT, 700)
 
     @JvmStatic
+    val researchSounds = config.getOrThrow("research.sounds", ConfigAdapter.LIST.from(ConfigAdapter.RANDOMIZED_SOUND))
+
+    @JvmStatic
     val pipePlacementTaskIntervalTicks = config.getOrThrow("pipe-placement.tick-interval", ConfigAdapter.LONG)
 
     @JvmStatic

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/PylonConfig.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/PylonConfig.kt
@@ -47,7 +47,7 @@ object PylonConfig {
     val researchMaxConfettiAmount = config.get("research.confetti.max-amount", ConfigAdapter.INT, 700)
 
     @JvmStatic
-    val researchSounds = config.getOrThrow("research.sounds", ConfigAdapter.LIST.from(ConfigAdapter.RANDOMIZED_SOUND))
+    val researchSounds = config.getOrThrow("research.sounds", ConfigAdapter.MAP.from(ConfigAdapter.LONG, ConfigAdapter.RANDOMIZED_SOUND))
 
     @JvmStatic
     val pipePlacementTaskIntervalTicks = config.getOrThrow("pipe-placement.tick-interval", ConfigAdapter.LONG)

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/ConfigAdapter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/ConfigAdapter.kt
@@ -39,7 +39,8 @@ interface ConfigAdapter<T> {
         @JvmField val MATERIAL = KEYED.fromRegistry(Registry.MATERIAL)
         @JvmField val ITEM_STACK = ItemStackConfigAdapter
         @JvmField val BLOCK_DATA = ConfigAdapter { Bukkit.createBlockData(STRING.convert(it)) }
-        @JvmField val SOUND = KEYED.fromRegistry(Registry.SOUNDS)
+        @JvmField val SOUND = SoundConfigAdapter
+        @JvmField val RANDOMIZED_SOUND = RandomizedSoundConfigAdapter
 
         @JvmField val PYLON_FLUID = KEYED.fromRegistry(PylonRegistry.FLUIDS)
         @JvmField val FLUID_TEMPERATURE = ENUM.from<FluidTemperature>()

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/ConfigAdapter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/ConfigAdapter.kt
@@ -18,12 +18,12 @@ interface ConfigAdapter<T> {
 
     companion object {
         // @formatter:off
-        @JvmField val BYTE = ConfigAdapter { (it as Number).toByte() }
-        @JvmField val SHORT = ConfigAdapter { (it as Number).toShort() }
-        @JvmField val INT = ConfigAdapter { (it as Number).toInt() }
-        @JvmField val LONG = ConfigAdapter { (it as Number).toLong() }
-        @JvmField val FLOAT = ConfigAdapter { (it as Number).toFloat() }
-        @JvmField val DOUBLE = ConfigAdapter { (it as Number).toDouble() }
+        @JvmField val BYTE = ConfigAdapter { if (it is String) it.toByte() else (it as Number).toByte() }
+        @JvmField val SHORT = ConfigAdapter { if (it is String) it.toShort() else (it as Number).toShort() }
+        @JvmField val INT = ConfigAdapter { if (it is String) it.toInt() else (it as Number).toInt() }
+        @JvmField val LONG = ConfigAdapter { if (it is String) it.toLong() else (it as Number).toLong() }
+        @JvmField val FLOAT = ConfigAdapter { if (it is String) it.toFloat() else (it as Number).toFloat() }
+        @JvmField val DOUBLE = ConfigAdapter { if (it is String) it.toDouble() else (it as Number).toDouble() }
         @JvmField val CHAR = ConfigAdapter { (it as String).single() }
         @JvmField val BOOLEAN = ConfigAdapter { it as Boolean }
         @JvmField val ANY = ConfigAdapter { it }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/ConfigAdapter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/ConfigAdapter.kt
@@ -2,6 +2,8 @@ package io.github.pylonmc.pylon.core.config.adapter
 
 import io.github.pylonmc.pylon.core.fluid.tags.FluidTemperature
 import io.github.pylonmc.pylon.core.registry.PylonRegistry
+import io.github.pylonmc.pylon.core.util.RandomizedSound
+import net.kyori.adventure.sound.Sound
 import org.bukkit.Bukkit
 import org.bukkit.NamespacedKey
 import org.bukkit.Registry
@@ -39,7 +41,48 @@ interface ConfigAdapter<T> {
         @JvmField val MATERIAL = KEYED.fromRegistry(Registry.MATERIAL)
         @JvmField val ITEM_STACK = ItemStackConfigAdapter
         @JvmField val BLOCK_DATA = ConfigAdapter { Bukkit.createBlockData(STRING.convert(it)) }
+
+        /**
+         * A [ConfigAdapter] for in game [Sound]s,
+         * comprised of a key, source, volume and pitch.
+         *
+         * For example:
+         * ```yaml
+         * hammer-sound:
+         *   sound: minecraft:block.anvil.use
+         *   source: player
+         *   volume: 0.5
+         *   pitch: 1.0
+         * ```
+         */
         @JvmField val SOUND = SoundConfigAdapter
+
+        /**
+         * A [ConfigAdapter] for [RandomizedSound]s,
+         * which accept either a single sound or a list of sounds, a source,
+         * and ranges for volume and pitch.
+         *
+         * Picking a random sound and a random volume and pitch from the ranges
+         * when played.
+         *
+         * The volume and pitch can either be specified as a single value,
+         * a list of two values (min and max), or specific min and max keys.
+         *
+         * For example:
+         * ```yaml
+         * hammer-sound:
+         *   sounds:
+         *   - minecraft:block.anvil.use
+         *   - minecraft:block.anvil.land
+         *   source: player
+         *   volume:
+         *     min: 0.3
+         *     max: 0.7
+         *   pitch:
+         *     - 0.8
+         *     - 1.2
+         *```
+         */
         @JvmField val RANDOMIZED_SOUND = RandomizedSoundConfigAdapter
 
         @JvmField val PYLON_FLUID = KEYED.fromRegistry(PylonRegistry.FLUIDS)

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/RandomizedSoundConfigAdapter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/RandomizedSoundConfigAdapter.kt
@@ -7,8 +7,7 @@ import org.bukkit.configuration.ConfigurationSection
 import java.lang.reflect.Type
 
 object RandomizedSoundConfigAdapter : ConfigAdapter<RandomizedSound> {
-    override val type: Type
-        get() = RandomizedSound::class.java
+    override val type: Type = RandomizedSound::class.java
 
     override fun convert(value: Any): RandomizedSound {
         val map = MapConfigAdapter.STRING_TO_ANY.convert(value)

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/RandomizedSoundConfigAdapter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/RandomizedSoundConfigAdapter.kt
@@ -1,0 +1,47 @@
+package io.github.pylonmc.pylon.core.config.adapter
+
+import io.github.pylonmc.pylon.core.util.RandomizedSound
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.sound.Sound
+import org.bukkit.configuration.ConfigurationSection
+import java.lang.reflect.Type
+
+object RandomizedSoundConfigAdapter : ConfigAdapter<RandomizedSound> {
+    override val type: Type
+        get() = RandomizedSound::class.java
+
+    override fun convert(value: Any): RandomizedSound {
+        val map = MapConfigAdapter.STRING_TO_ANY.convert(value)
+        val keys = mutableListOf<Key>()
+        if (map.containsKey("sound")) {
+            keys.add(Key.key(map["sound"]!! as String))
+        } else if (map.containsKey("sounds")) {
+            for (element in map["sounds"] as List<*>) {
+                keys.add(Key.key(element as String) )
+            }
+        } else {
+            throw IllegalArgumentException("No sound or sounds field found in section: $value")
+        }
+
+        return RandomizedSound(
+            keys,
+            ConfigAdapter.ENUM.from(Sound.Source::class.java).convert(map["source"]!!),
+            getRange(map, "volume"),
+            getRange(map, "pitch")
+        )
+    }
+
+    private fun getRange(section: Map<String, Any>, key: String): Pair<Double, Double> {
+        val range = section[key]!!
+        if (range is ConfigurationSection || range is Map<*, *>) {
+            val range = MapConfigAdapter.STRING_TO_ANY.convert(range)
+            return Pair((range["min"]!! as Number).toDouble(), (range["max"]!! as Number).toDouble())
+        } else if (range is List<*>) {
+            return Pair((range[0] as Number).toDouble(), (range[1] as Number).toDouble())
+        } else if (range is Number) {
+            val value = range.toDouble()
+            return Pair(value, value)
+        }
+        throw IllegalArgumentException("Cannot convert value to range: $range")
+    }
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/RandomizedSoundConfigAdapter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/RandomizedSoundConfigAdapter.kt
@@ -19,27 +19,34 @@ object RandomizedSoundConfigAdapter : ConfigAdapter<RandomizedSound> {
                 keys.add(Key.key(element as String) )
             }
         } else {
-            throw IllegalArgumentException("No sound or sounds field found in section: $value")
+            throw IllegalArgumentException("No 'sound' or 'sounds' field found in section: $value")
         }
 
         return RandomizedSound(
             keys,
-            ConfigAdapter.ENUM.from<Sound.Source>().convert(map["source"]!!),
+            ConfigAdapter.ENUM.from<Sound.Source>().convert(map["source"] ?: throw IllegalArgumentException("Sound is missing 'source' field")),
             getRange(map, "volume"),
             getRange(map, "pitch")
         )
     }
 
     private fun getRange(section: Map<String, Any>, key: String): Pair<Double, Double> {
-        val range = section[key]!!
+        val range = section[key] ?: throw IllegalArgumentException("Sound is missing '$key' field")
         if (range is ConfigurationSection || range is Map<*, *>) {
             val range = MapConfigAdapter.STRING_TO_ANY.convert(range)
-            return Pair(ConfigAdapter.DOUBLE.convert(range["min"]!!), ConfigAdapter.DOUBLE.convert(range["max"]!!))
+            return Pair(
+                ConfigAdapter.DOUBLE.convert(range["min"] ?: throw IllegalArgumentException("Sound is missing '$key.min' field")),
+                ConfigAdapter.DOUBLE.convert(range["max"] ?: throw IllegalArgumentException("Sound is missing '$key.max' field"))
+            )
         } else if (range is List<*>) {
             return Pair(ConfigAdapter.DOUBLE.convert(range[0]!!), ConfigAdapter.DOUBLE.convert(range[1]!!))
         } else {
-            val value = ConfigAdapter.DOUBLE.convert(range)
-            return Pair(value, value)
+            try {
+                val value = range.toString().toDouble()
+                return Pair(value, value)
+            } catch (_: Throwable) {
+                throw IllegalArgumentException("Sound '$key' field is not a valid number or range: $range")
+            }
         }
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/RandomizedSoundConfigAdapter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/RandomizedSoundConfigAdapter.kt
@@ -24,7 +24,7 @@ object RandomizedSoundConfigAdapter : ConfigAdapter<RandomizedSound> {
 
         return RandomizedSound(
             keys,
-            ConfigAdapter.ENUM.from(Sound.Source::class.java).convert(map["source"]!!),
+            ConfigAdapter.ENUM.from<Sound.Source>().convert(map["source"]!!),
             getRange(map, "volume"),
             getRange(map, "pitch")
         )
@@ -34,13 +34,12 @@ object RandomizedSoundConfigAdapter : ConfigAdapter<RandomizedSound> {
         val range = section[key]!!
         if (range is ConfigurationSection || range is Map<*, *>) {
             val range = MapConfigAdapter.STRING_TO_ANY.convert(range)
-            return Pair((range["min"]!! as Number).toDouble(), (range["max"]!! as Number).toDouble())
+            return Pair(ConfigAdapter.DOUBLE.convert(range["min"]!!), ConfigAdapter.DOUBLE.convert(range["max"]!!))
         } else if (range is List<*>) {
-            return Pair((range[0] as Number).toDouble(), (range[1] as Number).toDouble())
-        } else if (range is Number) {
-            val value = range.toDouble()
+            return Pair(ConfigAdapter.DOUBLE.convert(range[0]!!), ConfigAdapter.DOUBLE.convert(range[1]!!))
+        } else {
+            val value = ConfigAdapter.DOUBLE.convert(range)
             return Pair(value, value)
         }
-        throw IllegalArgumentException("Cannot convert value to range: $range")
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/SoundConfigAdapter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/SoundConfigAdapter.kt
@@ -11,9 +11,9 @@ object SoundConfigAdapter : ConfigAdapter<Sound> {
         val map = MapConfigAdapter.STRING_TO_ANY.convert(value)
         return Sound.sound(
             Key.key(map["name"] as String),
-            ConfigAdapter.ENUM.from<Sound.Source>().convert(map["source"]!!),
-            ConfigAdapter.FLOAT.convert(map["volume"]!!),
-            ConfigAdapter.FLOAT.convert(map["pitch"]!!)
+            ConfigAdapter.ENUM.from<Sound.Source>().convert(map["source"] ?: throw IllegalArgumentException("Sound is missing 'source' field")),
+            ConfigAdapter.FLOAT.convert(map["volume"] ?: throw IllegalArgumentException("Sound is missing 'volume' field")),
+            ConfigAdapter.FLOAT.convert(map["pitch"] ?: throw IllegalArgumentException("Sound is missing 'pitch' field"))
         )
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/SoundConfigAdapter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/SoundConfigAdapter.kt
@@ -5,8 +5,7 @@ import net.kyori.adventure.sound.Sound
 import java.lang.reflect.Type
 
 object SoundConfigAdapter : ConfigAdapter<Sound> {
-    override val type: Type
-        get() = Sound::class.java
+    override val type: Type = Sound::class.java
 
     override fun convert(value: Any): Sound {
         val map = MapConfigAdapter.STRING_TO_ANY.convert(value)

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/SoundConfigAdapter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/SoundConfigAdapter.kt
@@ -11,9 +11,9 @@ object SoundConfigAdapter : ConfigAdapter<Sound> {
         val map = MapConfigAdapter.STRING_TO_ANY.convert(value)
         Sound.sound(
             Key.key(map["name"] as String),
-            ConfigAdapter.ENUM.from(Sound.Source::class.java).convert(map["source"]!!),
-            (map["volume"] as Number).toFloat(),
-            (map["pitch"] as Number).toFloat()
+            ConfigAdapter.ENUM.from<Sound.Source>().convert(map["source"]!!),
+            ConfigAdapter.FLOAT.convert(map["volume"]!!),
+            ConfigAdapter.FLOAT.convert(map["pitch"]!!)
         )
         throw IllegalArgumentException("Cannot convert value to Sound: $value")
     }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/SoundConfigAdapter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/SoundConfigAdapter.kt
@@ -9,12 +9,11 @@ object SoundConfigAdapter : ConfigAdapter<Sound> {
 
     override fun convert(value: Any): Sound {
         val map = MapConfigAdapter.STRING_TO_ANY.convert(value)
-        Sound.sound(
+        return Sound.sound(
             Key.key(map["name"] as String),
             ConfigAdapter.ENUM.from<Sound.Source>().convert(map["source"]!!),
             ConfigAdapter.FLOAT.convert(map["volume"]!!),
             ConfigAdapter.FLOAT.convert(map["pitch"]!!)
         )
-        throw IllegalArgumentException("Cannot convert value to Sound: $value")
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/SoundConfigAdapter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/SoundConfigAdapter.kt
@@ -1,0 +1,23 @@
+package io.github.pylonmc.pylon.core.config.adapter
+
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.sound.Sound
+import org.bukkit.configuration.ConfigurationSection
+import java.lang.reflect.Type
+
+object SoundConfigAdapter : ConfigAdapter<Sound> {
+    override val type: Type
+        get() = Sound::class.java
+
+    override fun convert(value: Any): Sound {
+        if (value is ConfigurationSection) {
+            Sound.sound(
+                Key.key(value.getString("name")!!),
+                Sound.Source.valueOf(value.getString("source")!!.uppercase()),
+                value.getDouble("volume").toFloat(),
+                value.getDouble("pitch").toFloat()
+            )
+        }
+        throw IllegalArgumentException("Cannot convert value to Sound: $value")
+    }
+}

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/SoundConfigAdapter.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/config/adapter/SoundConfigAdapter.kt
@@ -1,8 +1,7 @@
 package io.github.pylonmc.pylon.core.config.adapter
 
 import net.kyori.adventure.key.Key
-import net.kyori.adventure.sound.Sound
-import org.bukkit.configuration.ConfigurationSection
+import net.kyori.adventure.sound.Sound 
 import java.lang.reflect.Type
 
 object SoundConfigAdapter : ConfigAdapter<Sound> {
@@ -10,14 +9,13 @@ object SoundConfigAdapter : ConfigAdapter<Sound> {
         get() = Sound::class.java
 
     override fun convert(value: Any): Sound {
-        if (value is ConfigurationSection) {
-            Sound.sound(
-                Key.key(value.getString("name")!!),
-                Sound.Source.valueOf(value.getString("source")!!.uppercase()),
-                value.getDouble("volume").toFloat(),
-                value.getDouble("pitch").toFloat()
-            )
-        }
+        val map = MapConfigAdapter.STRING_TO_ANY.convert(value)
+        Sound.sound(
+            Key.key(map["name"] as String),
+            ConfigAdapter.ENUM.from(Sound.Source::class.java).convert(map["source"]!!),
+            (map["volume"] as Number).toFloat(),
+            (map["pitch"] as Number).toFloat()
+        )
         throw IllegalArgumentException("Cannot convert value to Sound: $value")
     }
 }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/research/Research.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/research/Research.kt
@@ -100,14 +100,10 @@ data class Research(
             val spawnedConfetti = min(amount, PylonConfig.researchMaxConfettiAmount)
             ConfettiParticle.spawnMany(player.location, spawnedConfetti).run()
 
-            fun playSoundLater(sound: RandomizedSound, delay: Long) {
+            for ((delay, sound) in PylonConfig.researchSounds) {
                 Bukkit.getScheduler().runTaskLater(PylonCore, Runnable {
                     player.playSound(sound.create(), Sound.Emitter.self())
                 }, delay)
-            }
-
-            for ((delay, sound) in PylonConfig.researchSounds) {
-                playSoundLater(sound, delay)
             }
         }
     }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/research/Research.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/research/Research.kt
@@ -14,9 +14,11 @@ import io.github.pylonmc.pylon.core.recipe.FluidOrItem
 import io.github.pylonmc.pylon.core.recipe.RecipeType
 import io.github.pylonmc.pylon.core.recipe.vanilla.VanillaRecipeType
 import io.github.pylonmc.pylon.core.registry.PylonRegistry
+import io.github.pylonmc.pylon.core.util.RandomizedSound
 import io.github.pylonmc.pylon.core.util.persistentData
 import io.github.pylonmc.pylon.core.util.pylonKey
 import kotlinx.coroutines.delay
+import net.kyori.adventure.sound.Sound
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.event.HoverEvent
@@ -25,7 +27,6 @@ import org.bukkit.Keyed
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
 import org.bukkit.OfflinePlayer
-import org.bukkit.Sound
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
@@ -99,16 +100,16 @@ data class Research(
             val spawnedConfetti = min(amount, PylonConfig.researchMaxConfettiAmount)
             ConfettiParticle.spawnMany(player.location, spawnedConfetti).run()
 
-            fun Sound.playSoundLater(delay: Long, pitch: Float = 1f) {
+            fun playSoundLater(sound: RandomizedSound, delay: Long) {
                 Bukkit.getScheduler().runTaskLater(PylonCore, Runnable {
-                    player.playSound(player.location, this, 1.5f, pitch)
+                    player.playSound(sound.create(), Sound.Emitter.self())
                 }, delay)
             }
 
             repeat(2) {
-                Sound.ENTITY_FIREWORK_ROCKET_BLAST.playSoundLater(3L * it)
-                Sound.ENTITY_PLAYER_LEVELUP.playSoundLater(6L * it, 0.9f)
-                Sound.ENTITY_FIREWORK_ROCKET_LAUNCH.playSoundLater(9L * it)
+                playSoundLater(PylonConfig.researchSounds[0], 3L * it)
+                playSoundLater(PylonConfig.researchSounds[1], 6L * it)
+                playSoundLater(PylonConfig.researchSounds[2], 9L * it)
             }
         }
     }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/research/Research.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/research/Research.kt
@@ -106,10 +106,8 @@ data class Research(
                 }, delay)
             }
 
-            repeat(2) {
-                playSoundLater(PylonConfig.researchSounds[0], 3L * it)
-                playSoundLater(PylonConfig.researchSounds[1], 6L * it)
-                playSoundLater(PylonConfig.researchSounds[2], 9L * it)
+            for ((delay, sound) in PylonConfig.researchSounds) {
+                playSoundLater(sound, delay)
             }
         }
     }

--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/util/RandomizedSound.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/util/RandomizedSound.kt
@@ -1,0 +1,18 @@
+package io.github.pylonmc.pylon.core.util
+
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.sound.Sound
+
+data class RandomizedSound(
+    val keys: Collection<Key>,
+    val source: Sound.Source,
+    val volume: Pair<Double, Double>,
+    val pitch: Pair<Double, Double>
+) {
+    fun create() : Sound = Sound.sound(
+        keys.random(),
+        source,
+        (volume.first + Math.random() * (volume.second - volume.first)).toFloat(),
+        (pitch.first + Math.random() * (pitch.second - pitch.first)).toFloat()
+    )
+}

--- a/pylon-core/src/main/resources/config.yml
+++ b/pylon-core/src/main/resources/config.yml
@@ -33,19 +33,34 @@ research:
     multiplier: 0.2
     max-amount: 700 # must be an integer
   # The sounds played when a player unlocks a research
-  # There must always be 3 sounds
+  # The keys are the tick at which the sound is played, relative to after when the research is unlocked
   sounds:
-    -
-      sound: minecraft:entity.player.levelup
-      source: player
-      volume: 1.5
-      pitch: 0.9
-    -
+    2:
       sound: minecraft:entity.firework_rocket.blast
       source: player
       volume: 1.5
       pitch: 1
-    -
+    4:
+      sound: minecraft:entity.firework_rocket.blast
+      source: player
+      volume: 1.5
+      pitch: 1
+    6:
+      sound: minecraft:entity.player.levelup
+      source: player
+      volume: 1.5
+      pitch: 0.9
+    9:
+      sound: minecraft:entity.firework_rocket.launch
+      source: player
+      volume: 1.5
+      pitch: 1
+    12:
+      sound: minecraft:entity.player.levelup
+      source: player
+      volume: 1.5
+      pitch: 0.9
+    18:
       sound: minecraft:entity.firework_rocket.launch
       source: player
       volume: 1.5

--- a/pylon-core/src/main/resources/config.yml
+++ b/pylon-core/src/main/resources/config.yml
@@ -32,6 +32,24 @@ research:
     base-amount: 70.0
     multiplier: 0.2
     max-amount: 700 # must be an integer
+  # The sounds played when a player unlocks a research
+  # There must always be 3 sounds
+  sounds:
+    -
+      sound: minecraft:entity.player.levelup
+      source: player
+      volume: 1.5
+      pitch: 0.9
+    -
+      sound: minecraft:entity.firework_rocket.blast
+      source: player
+      volume: 1.5
+      pitch: 1
+    -
+      sound: minecraft:entity.firework_rocket.launch
+      source: player
+      volume: 1.5
+      pitch: 1
 
 pipe-placement:
   # The interval (in Minecraft ticks) between pipe placement task ticks


### PR DESCRIPTION
Changes the sound adapter to use adventures sound API for configurable volume and pitch.

This also adds a new utility class called RandomizedSound to allow supplying ranges for volume and pitch to better fit Minecraft which normally applies some randomness to sounds played so that they aren't fixed and as repetitive.

This is a breaking change and has a base pr that accounts for it.

> Note: I have have set all of the  sounds in here and there to use RandomizedSound but the default configs only give fixed values not a range yet, I just haven't gotten to changing it lol