### PR TITLE
Fix 'input' property of fluid buffers not being respected

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonFluidBufferBlock.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/block/base/PylonFluidBufferBlock.kt
@@ -130,7 +130,7 @@ interface PylonFluidBufferBlock : PylonFluidBlock {
     }
 
     override fun fluidAmountRequested(fluid: PylonFluid, deltaSeconds: Double): Double
-            = if (hasFluid(fluid)) fluidSpaceRemaining(fluid) else 0.0
+            = if (hasFluid(fluid) && fluidData(fluid).input) fluidSpaceRemaining(fluid) else 0.0
 
     override fun getSuppliedFluids(deltaSeconds: Double): Map<PylonFluid, Double>
             = fluidBuffers.filter { it.value.output }.mapValues { it.value.amount }


### PR DESCRIPTION
prior to this you could just input to any machine's fluid buffers...