### PR TITLE
Add InventoryEffectItem class

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/base/PylonInventoryEffectItem.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/base/PylonInventoryEffectItem.kt
@@ -17,9 +17,11 @@ interface PylonInventoryEffectItem : PylonInventoryTicker {
         tasks.putIfAbsent(itemKey, HashMap())
         tasks[itemKey]!![player.uniqueId]?.cancel()
         if (!player.persistentDataContainer.has(itemKey)) {
+            player.persistentDataContainer.set(itemKey, PersistentDataType.BOOLEAN, true)
             onAddedToInventory(player)
         }
         tasks[itemKey]!![player.uniqueId] = Bukkit.getScheduler().runTaskLater(PylonCore.javaPlugin, Runnable {
+            player.persistentDataContainer.remove(itemKey)
             onRemovedFromInventory(player)
         }, tickInterval * PylonConfig.inventoryTickerBaseRate + 1)
     }


### PR DESCRIPTION
Abstracts away the ugly scheduler implementation of a simple inventory effect item. Note that base will still use the talisman class for the talismans because this one doesn't have the concept of levels to make it more generally applicable