### PR TITLE
Item/research reorganisation

### DIFF
--- a/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/builder/ItemStackBuilder.kt
+++ b/pylon-core/src/main/kotlin/io/github/pylonmc/pylon/core/item/builder/ItemStackBuilder.kt
@@ -126,6 +126,9 @@ open class ItemStackBuilder internal constructor(val stack: ItemStack) : ItemPro
      */
     fun disableNameHacks() = editPdc { pdc -> pdc.set(disableNameHacksKey, PylonSerializers.BOOLEAN, true) }
 
+    fun lore(): ItemLore?
+        = stack.getData(DataComponentTypes.LORE)
+
     fun lore(loreToAdd: List<ComponentLike>) = apply {
         val lore = ItemLore.lore()
         stack.getData(DataComponentTypes.LORE)?.let { lore.addLines(it.lines()) }

--- a/pylon-core/src/main/resources/lang/en.yml
+++ b/pylon-core/src/main/resources/lang/en.yml
@@ -135,9 +135,9 @@ guide:
         <guidearrow> Example: <light_purple>@pylonbase <white>iron <aqua>$temperature <white>slurry
     research:
       cost:
-        not-enough: "<arrow> <attr>Unlock cost:</attr> <#e23b28>%points%/%cost%"
-        enough: "<arrow> <attr>Unlock cost:</attr> <#61ea38>%points%/%cost%"
-        researched: "<arrow> <attr>Unlock cost:</attr> <#61ea38>%cost% (researched)"
+        not-enough: "<arrow> <attr>Unlock cost:</attr> <#e23b28>%player_points%/%unlock_cost%"
+        enough: "<arrow> <attr>Unlock cost:</attr> <#61ea38>%player_points%/%unlock_cost%"
+        researched: "<arrow> <attr>Unlock cost:</attr> <#61ea38>%unlock_cost% (researched)"
       hints:
         research: |-
           
@@ -163,8 +163,11 @@ guide:
           <guidearrow> <guideinsn>Left click</guideinsn> to see recipe
           <guidearrow> <guideinsn>Right click</guideinsn> to see usages
     item:
-      not-researched: "<red><u>Not researched yet</u>"
-      not-researched-with-name: "<red><u>Not researched yet <gray>(%research_name%<gray>)"
+      not-researched:
+        no-research-cost: "<guidearrow> <red>Unresearched"
+        enough-points: "<guidearrow> <red>Unresearched <gray>(%research_name% <gray>| <#61ea38>%player_points%/%unlock_cost%<gray>)"
+        not-enough-points: "<guidearrow> <red>Unresearched <gray>(%research_name% <gray>| <#e23b28>%player_points%/%unlock_cost%<gray>)"
+
       hints:
         researched: |-
           


### PR DESCRIPTION
Companion to https://github.com/pylonmc/pylon-base/pull/561

- Makes research lore one line at the start so it looks less intimidating
- Allows Pylon items to be used to represent researches

closes https://github.com/pylonmc/pylon-base/issues/558