### PR TITLE
fix(rebar): gracefully handle missing held entities on deserialize

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarEntityHolderBlock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarEntityHolderBlock.kt
@@ -138,7 +138,7 @@ interface RebarEntityHolderBlock {
             val block = event.rebarBlock
             if (block !is RebarEntityHolderBlock) return
             holders[block] = event.pdc.get(entityKey, entityType)?.toMutableMap()
-                ?: error("Held entities not found for ${block.key}")
+                ?: mutableMapOf()
         }
 
         @EventHandler


### PR DESCRIPTION
## Description
`RebarEntityHolderBlock` strict-checked that the `entityKey` map was present in the chunk `PersistentDataContainer` during deserialization. If it went missing (due to server restart glitches or chunk loading issues), the block threw an `error()`, triggering an `IllegalStateException` and failing the entire chunk load sequence. This was particularly spammy for `fluid_pipe_intersection_marker` blocks.

## Fix
Replaced the `error()` fallback with `mutableMapOf()` in `onDeserialize`. The chunk will now load successfully without the entities, allowing the server to clean up or overwrite the block naturally instead of entering a crash loop.
