### PR TITLE
fix(guide): hide gameplay tooltips on unresearched guide items

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/button/ItemButton.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/button/ItemButton.kt
@@ -91,6 +91,7 @@ class ItemButton @JvmOverloads constructor(
             if (!player.canCraft(item, respectBypass = false)) {
                 builder.set(DataComponentTypes.ITEM_MODEL, Material.BARRIER.key)
                     .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, false)
+                    .clearLore()
 
                 val research = item.research
                 if (research != null) {
@@ -107,10 +108,7 @@ class ItemButton @JvmOverloads constructor(
                         Component.translatable("rebar.guide.button.item.not-researched")
                     }
 
-                    val lore = builder.lore()?.lines()?.toMutableList() ?: mutableListOf()
-                    lore.add(0, loreLine)
-                    builder.clearLore()
-                    builder.lore(lore)
+                    builder.lore(loreLine)
                 }
             }
 


### PR DESCRIPTION
In ItemButton.kt, unresearched items had their model overridden to a Barrier block and a "not-researched" lore line prepended. However, the ItemStackBuilder retained the original item's metadata and tooltips, allowing players to view gameplay mechanic hints on locked items.

Fixed by chaining .clearLore() right after assigning the Barrier model, ensuring only the "Not enough research points" warning remains visible. Fixes pylonmc/pylon#660

**Verified by updating the rebar plugin and pasting into the pylon plugin folder and restarting server.**

Before Fix:
<img width="1920" height="1080" alt="2026-02-24_14 56 44" src="https://github.com/user-attachments/assets/5571d011-77a2-482b-bdae-6450d9954a83" />

After Fix:
<img width="1920" height="1080" alt="2026-02-24_14 53 26" src="https://github.com/user-attachments/assets/901c7551-93e8-4f95-9123-255229afc77a" />

