### PR TITLE
Resolve kotlin compiler issue with paper's `Keyed` interface

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/RebarBlock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/RebarBlock.kt
@@ -63,8 +63,7 @@ open class RebarBlock internal constructor(val block: Block) : Keyed {
      */
     val schema = RebarBlockSchema.schemaCache.remove(block.position)!!
 
-    val key = schema.key
-    override fun getKey(): NamespacedKey = key
+    override fun getKey(): NamespacedKey = schema.key
 
     val nameTranslationKey = schema.nameTranslationKey
     val loreTranslationKey = schema.loreTranslationKey


### PR DESCRIPTION
basically, what the issue was (at least i think so, and fixing it with such thinking resolves it), is that `RebarDirectionalBlock` implements `Keyed`, which has a `getKey()` method, which gets overrode by [RebarBlock#key](https://github.com/pylonmc/rebar/blob/master/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/RebarBlock.kt#L65), resulting in machines which implement both `RebarBlock` and `RebarDirectionalBlock` having an issue when overriding `getKey()` (which shouldn't be done):

```
Accidental override: The following declarations have the same JVM signature (getKey()Lorg/bukkit/NamespacedKey;):
    fun `<get-key>`(): NamespacedKey defined in me.glomdom.gantry.content.machines.hydraulics.HydraulicFormingPress
    fun getKey(): NamespacedKey defined in me.glomdom.gantry.content.machines.hydraulics.HydraulicFormingPress
```

this is fixed by `RebarBlock` implementing `Keyed` and changing the getter for `key` to be `getRebarKey`, and overriding `Keyed`'s `getKey` to return the said `key`.

i have tested this with a snapshot version of Pylon and there hasnt been any issues, and my addon's machines work properly as well.