### PR TITLE
Private `RebarBlock(Rebar)` constructor

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/PhantomBlock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/PhantomBlock.kt
@@ -41,7 +41,7 @@ class PhantomBlock(
     val pdc: PersistentDataContainer,
     val erroredBlockKey: NamespacedKey,
     block: Block
-) : RebarBlock(block), RebarBreakHandler {
+) : RebarBlock(block, pdc), RebarBreakHandler {
 
     override var disableBlockTextureEntity: Boolean = true
     private var errorOutlineEntityId : UUID? = null

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/RebarBlock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/RebarBlock.kt
@@ -30,11 +30,7 @@ import io.github.retrooper.packetevents.util.SpigotConversionUtil
 import io.papermc.paper.datacomponent.DataComponentTypes
 import me.tofaa.entitylib.meta.display.ItemDisplayMeta
 import net.kyori.adventure.key.Key
-import org.bukkit.Bukkit
-import org.bukkit.Keyed
-import org.bukkit.Material
-import org.bukkit.NamespacedKey
-import org.bukkit.World
+import org.bukkit.*
 import org.bukkit.block.Block
 import org.bukkit.entity.ItemDisplay
 import org.bukkit.entity.Player
@@ -56,7 +52,7 @@ import org.bukkit.persistence.PersistentDataContainer
  *
  * @see BlockStorage
  */
-open class RebarBlock internal constructor(val block: Block) : Keyed {
+open class RebarBlock private constructor(val block: Block) : Keyed {
 
     /**
      * All the data needed to create or load the block.
@@ -107,7 +103,7 @@ open class RebarBlock internal constructor(val block: Block) : Keyed {
     /**
      * This constructor is called when a *new* block is created in the world.
      */
-    constructor(block: Block, context: BlockCreateContext) : this(block)
+    constructor(block: Block, @Suppress("unused") context: BlockCreateContext) : this(block)
 
     /**
      * This constructor is called when the block is loaded. For example, if the server
@@ -121,7 +117,7 @@ open class RebarBlock internal constructor(val block: Block) : Keyed {
      *
      * @see PersistentDataContainer
      */
-    constructor(block: Block, pdc: PersistentDataContainer) : this(block)
+    constructor(block: Block, @Suppress("unused") pdc: PersistentDataContainer) : this(block)
 
     /**
      * Called after the load constructor.

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/cargo/CargoDuct.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/cargo/CargoDuct.kt
@@ -40,12 +40,12 @@ class CargoDuct : RebarBlock, RebarBreakHandler, RebarEntityHolderBlock, RebarEn
     override var disableBlockTextureEntity = true
 
     @Suppress("unused")
-    constructor(block: Block, context: BlockCreateContext) : super(block) {
+    constructor(block: Block, context: BlockCreateContext) : super(block, context) {
         updateConnectedFaces()
     }
 
     @Suppress("unused")
-    constructor(block: Block, pdc: PersistentDataContainer) : super(block) {
+    constructor(block: Block, pdc: PersistentDataContainer) : super(block, pdc) {
         connectedFaces = pdc.get(connectedFacesKey, connectedFacesType)!!.toMutableList()
     }
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/fluid/FluidIntersectionMarker.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/fluid/FluidIntersectionMarker.kt
@@ -28,12 +28,12 @@ class FluidIntersectionMarker : RebarBlock, RebarEntityHolderBlock, RebarBreakHa
     override var disableBlockTextureEntity = true
 
     @Suppress("unused")
-    constructor(block: Block, context: BlockCreateContext) : super(block) {
+    constructor(block: Block, context: BlockCreateContext) : super(block, context) {
         addEntity("intersection", FluidIntersectionDisplay(block))
     }
 
     @Suppress("unused")
-    constructor(block: Block, pdc: PersistentDataContainer) : super(block)
+    constructor(block: Block, pdc: PersistentDataContainer) : super(block, pdc)
 
     val fluidIntersectionDisplay
         get() = getHeldRebarEntityOrThrow(FluidIntersectionDisplay::class.java, "intersection")

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/fluid/FluidSectionMarker.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/fluid/FluidSectionMarker.kt
@@ -26,10 +26,10 @@ class FluidSectionMarker : RebarBlock, RebarBreakHandler, RebarEntityHolderBlock
     override var disableBlockTextureEntity = true
 
     @Suppress("unused")
-    constructor(block: Block, context: BlockCreateContext) : super(block)
+    constructor(block: Block, context: BlockCreateContext) : super(block, context)
 
     @Suppress("unused")
-    constructor(block: Block, pdc: PersistentDataContainer) : super(block)
+    constructor(block: Block, pdc: PersistentDataContainer) : super(block, pdc)
 
     val pipeDisplay
         get() = getHeldRebarEntity(FluidPipeDisplay::class.java, "pipe")

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/BlockWithField.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/BlockWithField.java
@@ -20,13 +20,13 @@ public class BlockWithField extends RebarBlock {
 
     @SuppressWarnings("unused")
     public BlockWithField(Block block, BlockCreateContext context) {
-        super(block);
+        super(block, context);
         progress = 240;
     }
 
     @SuppressWarnings({"unused", "DataFlowIssue"})
     public BlockWithField(Block block, PersistentDataContainer pdc) {
-        super(block);
+        super(block, pdc);
         progress = pdc.get(PROGRESS_KEY, PersistentDataType.INTEGER);
     }
 

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/TestRebarSimpleMultiblock.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/TestRebarSimpleMultiblock.java
@@ -19,12 +19,12 @@ public class TestRebarSimpleMultiblock extends RebarBlock implements RebarSimple
 
     @SuppressWarnings("unused")
     public TestRebarSimpleMultiblock(Block block, BlockCreateContext context) {
-        super(block);
+        super(block, context);
     }
 
     @SuppressWarnings("unused")
     public TestRebarSimpleMultiblock(Block block, PersistentDataContainer pdc) {
-        super(block);
+        super(block, pdc);
     }
 
     @Override

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/TickingBlock.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/TickingBlock.java
@@ -16,13 +16,13 @@ public class TickingBlock extends RebarBlock implements RebarTickingBlock {
     public int ticks = 0;
 
     @SuppressWarnings("unused")
-    public TickingBlock (Block block, BlockCreateContext context) {
-        super(block);
+    public TickingBlock(Block block, BlockCreateContext context) {
+        super(block, context);
     }
 
     @SuppressWarnings("unused")
-    public TickingBlock (Block block, PersistentDataContainer pdc) {
-        super(block);
+    public TickingBlock(Block block, PersistentDataContainer pdc) {
+        super(block, pdc);
     }
 
     @Override

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/TickingErrorBlock.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/TickingErrorBlock.java
@@ -15,12 +15,12 @@ public class TickingErrorBlock extends RebarBlock implements RebarTickingBlock {
 
     @SuppressWarnings("unused")
     public TickingErrorBlock(Block block, BlockCreateContext context) {
-        super(block);
+        super(block, context);
     }
 
     @SuppressWarnings("unused")
     public TickingErrorBlock(Block block, PersistentDataContainer pdc) {
-        super(block);
+        super(block, pdc);
     }
 
     @Override

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/fluid/FluidConnector.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/fluid/FluidConnector.java
@@ -26,14 +26,14 @@ public class FluidConnector extends RebarBlock implements RebarUnloadBlock {
 
     @SuppressWarnings("unused")
     public FluidConnector(Block block, BlockCreateContext context) {
-        super(block);
+        super(block, context);
         point = new VirtualFluidPoint(block, FluidPointType.INTERSECTION);
         FluidManager.add(point);
     }
 
     @SuppressWarnings("unused")
     public FluidConnector(Block block, PersistentDataContainer pdc) {
-        super(block);
+        super(block, pdc);
         point = pdc.get(POINT_KEY, RebarSerializers.FLUID_CONNECTION_POINT);
         FluidManager.add(point);
     }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/fluid/FluidConsumer.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/fluid/FluidConsumer.java
@@ -34,7 +34,7 @@ public class FluidConsumer extends RebarBlock implements RebarFluidBufferBlock, 
 
     @SuppressWarnings("unused")
     public FluidConsumer(Block block, BlockCreateContext context) {
-        super(block);
+        super(block, context);
         point = new VirtualFluidPoint(block, FluidPointType.INPUT);
         FluidManager.add(point);
         createFluidBuffer(getFluidType(), CAPACITY, true, false);
@@ -42,7 +42,7 @@ public class FluidConsumer extends RebarBlock implements RebarFluidBufferBlock, 
 
     @SuppressWarnings("unused")
     public FluidConsumer(Block block, PersistentDataContainer pdc) {
-        super(block);
+        super(block, pdc);
         point = pdc.get(pointKey, RebarSerializers.FLUID_CONNECTION_POINT);
         FluidManager.add(point);
     }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/fluid/FluidLimiter.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/fluid/FluidLimiter.java
@@ -31,7 +31,7 @@ public class FluidLimiter extends RebarBlock implements RebarFluidTank, RebarUnl
 
     @SuppressWarnings("unused")
     public FluidLimiter(Block block, BlockCreateContext context) {
-        super(block);
+        super(block, context);
 
         input = new VirtualFluidPoint(block, FluidPointType.INPUT);
         output = new VirtualFluidPoint(block, FluidPointType.OUTPUT);
@@ -42,7 +42,7 @@ public class FluidLimiter extends RebarBlock implements RebarFluidTank, RebarUnl
 
     @SuppressWarnings("unused")
     public FluidLimiter(Block block, PersistentDataContainer pdc) {
-        super(block);
+        super(block, pdc);
 
         input = pdc.get(INPUT_KEY, RebarSerializers.FLUID_CONNECTION_POINT);
         output = pdc.get(OUTPUT_KEY, RebarSerializers.FLUID_CONNECTION_POINT);

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/fluid/FluidProducer.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/fluid/FluidProducer.java
@@ -34,14 +34,14 @@ public class FluidProducer extends RebarBlock implements RebarFluidBlock, RebarU
 
     @SuppressWarnings("unused")
     public FluidProducer(@NotNull Block block, @NotNull BlockCreateContext context) {
-        super(block);
+        super(block, context);
         point = new VirtualFluidPoint(block, FluidPointType.OUTPUT);
         FluidManager.add(point);
     }
 
     @SuppressWarnings("unused")
     public FluidProducer(@NotNull Block block, @NotNull PersistentDataContainer pdc) {
-        super(block);
+        super(block, pdc);
         point = pdc.get(pointKey, RebarSerializers.FLUID_CONNECTION_POINT);
         FluidManager.add(point);
     }


### PR DESCRIPTION
Previously it was `internal`, which did not prevent Java from accessing it. Making it private reduces the chance of erroneous constructor overrides and forces the player to call the correct super constructor.