### PR TITLE
Early game smelting rework

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarFluidBufferBlock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarFluidBufferBlock.kt
@@ -94,7 +94,7 @@ interface RebarFluidBufferBlock : RebarFluidBlock {
      * the corresponding buffer.
      */
     fun canSetFluid(fluid: RebarFluid, amount: Double): Boolean
-            = amount >= 0 && amount <= fluidData(fluid).capacity + FLUID_EPSILON
+            = fluid in fluidBuffers && amount >= 0 && amount <= fluidData(fluid).capacity + FLUID_EPSILON
 
     /**
      * Sets a fluid buffer only if the new amount of fluid is greater

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarRecipeProcessor.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarRecipeProcessor.kt
@@ -49,6 +49,14 @@ interface RebarRecipeProcessor<T: RebarRecipe> {
         @ApiStatus.NonExtendable
         get() = recipeProcessorData.recipeTicksRemaining
 
+    val recipeTimeTicks: Int?
+        @ApiStatus.NonExtendable
+        get() = recipeProcessorData.recipeTimeTicks
+
+    val recipeProgress: Double?
+        @ApiStatus.NonExtendable
+        get() = recipeTimeTicks?.let { recipeTicksRemaining?.toDouble()?.div(it) }
+
     val isProcessingRecipe: Boolean
         @ApiStatus.NonExtendable
         get() = currentRecipe != null

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarRecipeProcessor.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarRecipeProcessor.kt
@@ -62,15 +62,22 @@ interface RebarRecipeProcessor<T: RebarRecipe> {
         get() = currentRecipe != null
 
     var recipeProgressItem: ProgressItem
+        @ApiStatus.NonExtendable
         get() = recipeProcessorData.progressItem ?: error("No recipe progress item was set")
+        /**
+         * Set the progress item that should be updated as the recipe progresses. Optional.
+         *
+         * Call once in your place constructor. Do not call this function again after that.
+         * If you need to modify the progress item, use `getProgressItem()` and modify the
+         * itemstack returned from that instead.
+         */
+        @ApiStatus.NonExtendable
         set(progressItem) {
             recipeProcessorData.progressItem = progressItem
         }
 
     /**
-     * Set the progress item that should be updated as the recipe progresses. Optional.
-     *
-     * Set once in your place constructor.
+     * Call once in your place constructor.
      */
     @ApiStatus.NonExtendable
     fun setRecipeType(type: RecipeType<T>) {

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/button/ItemButton.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/button/ItemButton.kt
@@ -217,7 +217,7 @@ class ItemButton @JvmOverloads constructor(
         }
 
         @JvmStatic
-        fun from(stack: ItemStack?): Item {
+        fun of(stack: ItemStack?): Item {
             if (stack == null) {
                 return EMPTY
             }
@@ -226,7 +226,7 @@ class ItemButton @JvmOverloads constructor(
         }
 
         @JvmStatic
-        fun from(stack: ItemStack?, preDisplayDecorator: (ItemStack, Player) -> ItemStack):  Item {
+        fun of(stack: ItemStack?, preDisplayDecorator: (ItemStack, Player) -> ItemStack): Item {
             if (stack == null) {
                 return EMPTY
             }
@@ -235,7 +235,7 @@ class ItemButton @JvmOverloads constructor(
         }
 
         @JvmStatic
-        fun from(input: RecipeInput.Item?): Item {
+        fun of(input: RecipeInput.Item?): Item {
             if (input == null) {
                 return EMPTY
             }
@@ -244,10 +244,29 @@ class ItemButton @JvmOverloads constructor(
         }
 
         @JvmStatic
-        fun from(choice: RecipeChoice?): Item = when (choice) {
+        fun of(choice: RecipeChoice?): Item = when (choice) {
             is RecipeChoice.MaterialChoice -> ItemButton(choice.choices.map(::ItemStack))
             is RecipeChoice.ExactChoice -> ItemButton(choice.choices)
             else -> EMPTY
         }
+
+        @JvmStatic @JvmOverloads
+        fun of(stacks: List<ItemStack>, preDisplayDecorator: (ItemStack, Player) -> ItemStack = { stack, _ -> stack })
+                = ItemButton(stacks, preDisplayDecorator)
+        /**
+         * @param stacks The items to display. If multiple are provided, the button will automatically
+         * cycle through all of them. You must supply at least one item
+         */
+        @JvmStatic
+        fun of(vararg stacks: ItemStack)
+                = ItemButton(stacks.toList())
+
+        /**
+         * @param stacks The items to display. If multiple are provided, the button will automatically
+         * cycle through all of them. You must supply at least one item
+         */
+        @JvmStatic
+        fun of(stack: ItemStack, preDisplayDecorator: (ItemStack, Player) -> ItemStack)
+                = ItemButton(stack, preDisplayDecorator)
     }
 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/fluid/FluidRecipesPage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/fluid/FluidRecipesPage.kt
@@ -3,6 +3,8 @@ package io.github.pylonmc.rebar.guide.pages.fluid
 import io.github.pylonmc.rebar.content.guide.RebarGuide
 import io.github.pylonmc.rebar.guide.pages.base.PagedGuidePage
 import io.github.pylonmc.rebar.recipe.FluidOrItem
+import io.github.pylonmc.rebar.recipe.RebarRecipe
+import io.github.pylonmc.rebar.recipe.RebarRecipe.Companion.priority
 import io.github.pylonmc.rebar.registry.RebarRegistry
 import io.github.pylonmc.rebar.util.gui.GuiItems
 import io.github.pylonmc.rebar.util.rebarKey
@@ -21,11 +23,19 @@ open class FluidRecipesPage(fluidKey: NamespacedKey) : PagedGuidePage {
     val pages: MutableList<Gui>
         get() {
             val pages = mutableListOf<Gui>()
+            val recipes = mutableListOf<RebarRecipe>()
             for (type in RebarRegistry.RECIPE_TYPES) {
                 for (recipe in type.recipes) {
                     if (!recipe.isHidden && recipe.isOutput(fluid)) {
-                        recipe.display()?.let { pages.add(it) }
+                        recipes.add(recipe)
                     }
+                }
+            }
+            recipes.sortByDescending { it.priority }
+            for (recipe in recipes) {
+                val display = recipe.display()
+                if (display != null) {
+                    pages.add(display)
                 }
             }
             return pages

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/item/ItemRecipesPage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/item/ItemRecipesPage.kt
@@ -8,6 +8,7 @@ import io.github.pylonmc.rebar.recipe.RebarRecipe.Companion.priority
 import io.github.pylonmc.rebar.registry.RebarRegistry
 import io.github.pylonmc.rebar.util.gui.GuiItems
 import io.github.pylonmc.rebar.util.rebarKey
+import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import xyz.xenondevs.invui.gui.Gui

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/item/ItemRecipesPage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/item/ItemRecipesPage.kt
@@ -8,7 +8,6 @@ import io.github.pylonmc.rebar.recipe.RebarRecipe.Companion.priority
 import io.github.pylonmc.rebar.registry.RebarRegistry
 import io.github.pylonmc.rebar.util.gui.GuiItems
 import io.github.pylonmc.rebar.util.rebarKey
-import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import xyz.xenondevs.invui.gui.Gui

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/RebarRecipe.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/RebarRecipe.kt
@@ -16,7 +16,7 @@ interface RebarRecipe : Keyed {
 
     fun isInput(stack: ItemStack) = inputs.any { input ->
         when (input) {
-            is RecipeInput.Item -> stack in input
+            is RecipeInput.Item -> input.matchesIgnoringAmount(stack)
             else -> false
         }
     }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/RecipeInput.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/RecipeInput.kt
@@ -23,12 +23,12 @@ sealed interface RecipeInput {
             representativeItems.first()
         }
 
-        fun matches(itemStack: ItemStack): Boolean {
-            if (itemStack.amount < amount) return false
+        fun matches(itemStack: ItemStack?): Boolean {
+            if (itemStack == null || itemStack.amount < amount) return false
             return contains(itemStack)
         }
 
-        operator fun contains(itemStack: ItemStack): Boolean = ItemTypeWrapper(itemStack) in items
+        operator fun contains(itemStack: ItemStack?): Boolean = itemStack != null && ItemTypeWrapper(itemStack) in items
     }
 
     @JvmRecord
@@ -41,12 +41,12 @@ sealed interface RecipeInput {
             require(fluids.isNotEmpty()) { "Fluids set must not be empty" }
         }
 
-        fun matches(fluid: RebarFluid, amountMillibuckets: Double): Boolean {
-            if (amountMillibuckets < this.amountMillibuckets) return false
+        fun matches(fluid: RebarFluid?, amountMillibuckets: Double): Boolean {
+            if (fluid == null || amountMillibuckets < this.amountMillibuckets) return false
             return contains(fluid)
         }
 
-        operator fun contains(fluid: RebarFluid): Boolean = fluid in fluids
+        operator fun contains(fluid: RebarFluid?): Boolean = fluid in fluids
     }
 
     companion object {

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/RecipeInput.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/RecipeInput.kt
@@ -25,10 +25,10 @@ sealed interface RecipeInput {
 
         fun matches(itemStack: ItemStack?): Boolean {
             if (itemStack == null || itemStack.amount < amount) return false
-            return contains(itemStack)
+            return matchesIgnoringAmount(itemStack)
         }
 
-        operator fun contains(itemStack: ItemStack?): Boolean = itemStack != null && ItemTypeWrapper(itemStack) in items
+        fun matchesIgnoringAmount(itemStack: ItemStack?): Boolean = itemStack != null && ItemTypeWrapper(itemStack) in items
     }
 
     @JvmRecord

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/Cooking.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/Cooking.kt
@@ -34,7 +34,7 @@ sealed class CookingRecipeWrapper(final override val recipe: CookingRecipe<*>) :
         )
         .addIngredient('#', GuiItems.backgroundBlack())
         .addIngredient('b', ItemStack(displayBlock))
-        .addIngredient('i', ItemButton.from(recipe.inputChoice))
+        .addIngredient('i', ItemButton.of(recipe.inputChoice))
         .addIngredient(
             'f', GuiItems.progressCyclingItem(
                 recipe.cookingTime,
@@ -47,7 +47,7 @@ sealed class CookingRecipeWrapper(final override val recipe: CookingRecipe<*>) :
                     )
             )
         )
-        .addIngredient('o', ItemButton.from(recipe.result))
+        .addIngredient('o', ItemButton.of(recipe.result))
         .build()
 }
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/Crafting.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/Crafting.kt
@@ -37,8 +37,8 @@ class ShapedRecipeWrapper(override val recipe: ShapedRecipe) : CraftingRecipeWra
                 "# # # # # # # # #",
             )
             .addIngredient('#', GuiItems.backgroundBlack())
-            .addIngredient('b', ItemButton.from(ItemStack(Material.CRAFTING_TABLE)))
-            .addIngredient('r', ItemButton.from(recipe.result))
+            .addIngredient('b', ItemButton.of(ItemStack(Material.CRAFTING_TABLE)))
+            .addIngredient('r', ItemButton.of(recipe.result))
             .build()
 
         val height = recipe.shape.size
@@ -54,7 +54,7 @@ class ShapedRecipeWrapper(override val recipe: ShapedRecipe) : CraftingRecipeWra
 
     private fun getDisplaySlot(recipe: ShapedRecipe, x: Int, y: Int): Item {
         val character = recipe.shape[y][x]
-        return ItemButton.from(recipe.choiceMap[character])
+        return ItemButton.of(recipe.choiceMap[character])
     }
 }
 
@@ -73,7 +73,7 @@ sealed class AShapelessRecipeWrapper(recipe: CraftingRecipe) : CraftingRecipeWra
             "# # # # # # # # #",
         )
         .addIngredient('#', GuiItems.backgroundBlack())
-        .addIngredient('b', ItemButton.from(ItemStack(Material.CRAFTING_TABLE)))
+        .addIngredient('b', ItemButton.of(ItemStack(Material.CRAFTING_TABLE)))
         .addIngredient('0', getDisplaySlot(0))
         .addIngredient('1', getDisplaySlot(1))
         .addIngredient('2', getDisplaySlot(2))
@@ -87,7 +87,7 @@ sealed class AShapelessRecipeWrapper(recipe: CraftingRecipe) : CraftingRecipeWra
         .build()
 
     private fun getDisplaySlot(index: Int): Item {
-        return ItemButton.from(choiceList.getOrNull(index))
+        return ItemButton.of(choiceList.getOrNull(index))
     }
 }
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/Smithing.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/Smithing.kt
@@ -32,11 +32,11 @@ sealed class SmithingRecipeWrapper(recipe: SmithingRecipe) : VanillaRecipeWrappe
             "# # # # # # # # #",
         )
         .addIngredient('#', GuiItems.backgroundBlack())
-        .addIngredient('b', ItemButton.from(ItemStack(Material.SMITHING_TABLE)))
+        .addIngredient('b', ItemButton.of(ItemStack(Material.SMITHING_TABLE)))
         .addIngredient('0', ItemStack(Material.NETHERITE_UPGRADE_SMITHING_TEMPLATE))
-        .addIngredient('1', ItemButton.from(recipe.base))
-        .addIngredient('2', ItemButton.from(recipe.addition))
-        .addIngredient('r', ItemButton.from(recipe.result))
+        .addIngredient('1', ItemButton.of(recipe.base))
+        .addIngredient('2', ItemButton.of(recipe.addition))
+        .addIngredient('r', ItemButton.of(recipe.result))
         .build()
 
     override fun getKey(): NamespacedKey = recipe.key

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/util/gui/ProgressItem.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/util/gui/ProgressItem.kt
@@ -54,6 +54,7 @@ open class ProgressItem @JvmOverloads constructor(
 
     fun setItem(item: Item) {
         this.item = item
+        notifyWindows()
     }
 
     fun setItem(stack: ItemStack) {


### PR DESCRIPTION
Companion PR to https://github.com/pylonmc/pylon/pull/931

- Allow passing null to recipe input `matches` for convenience
- Changed ItemButton.from to ItemButton.of for consistency with other classes
- Fixed fluid recipes not being ordered by priority
- Added .of methods to ItemButton for consistency to mirror constructor