### PR TITLE
fix: use `Enchantment#description()` for MiniMessage `enchantment` tag

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/RebarMiniMessage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/RebarMiniMessage.kt
@@ -155,7 +155,7 @@ private fun enchantment(args: ArgumentQueue, ctx: Context): Tag {
     val enchantment = RegistryAccess.registryAccess().getRegistry(RegistryKey.ENCHANTMENT).get(nsKey)
         ?: throw ctx.newException("Unknown enchantment: $nsKey")
 
-    return Tag.selfClosingInserting(Component.translatable(enchantment.translationKey()))
+    return Tag.selfClosingInserting(enchantment.description())
 }
 
 private fun biome(args: ArgumentQueue, ctx: Context): Tag {


### PR DESCRIPTION
Not all enchantments have a translation key. Using `Enchantment#translationKey()` can cause error if the enchantment description is not translatable (like in RebarMobs, all the Enchantment descriptions are simple text components)