### PR TITLE
Make the recipes map linked

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/RecipeType.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/RecipeType.kt
@@ -6,7 +6,6 @@ import org.bukkit.Bukkit
 import org.bukkit.Keyed
 import org.bukkit.NamespacedKey
 import org.bukkit.inventory.*
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Serves as a registry and container for recipes of a specific type.
@@ -16,7 +15,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 open class RecipeType<T : RebarRecipe>(private val key: NamespacedKey) : Keyed, Iterable<T> {
 
-    protected open val registeredRecipes = ConcurrentHashMap<NamespacedKey, T>()
+    protected open val registeredRecipes = LinkedHashMap<NamespacedKey, T>()
     val recipes: Collection<T>
         get() = registeredRecipes.values
 


### PR DESCRIPTION
We don't ever register recipes async, and I would very much like the recipes to be stored in the order I registered them for the forming table