### PR TITLE
Ghost block + multiblock component refactor

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/Rebar.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/Rebar.kt
@@ -61,6 +61,7 @@ import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
 import org.bukkit.configuration.file.YamlConfiguration
+import org.bukkit.entity.BlockDisplay
 import org.bukkit.entity.Display
 import org.bukkit.entity.FallingBlock
 import org.bukkit.entity.ItemDisplay
@@ -292,8 +293,12 @@ object Rebar : JavaPlugin(), RebarAddon {
         RebarItem.register<RebarGuide>(RebarGuide.STACK)
         RebarGuide.hideItem(RebarGuide.KEY)
 
-        RebarEntity.register<Display, RebarSimpleMultiblock.MultiblockGhostBlock>(
-            RebarSimpleMultiblock.MultiblockGhostBlock.KEY,
+        RebarEntity.register<BlockDisplay, RebarGhostBlockHolder.VanillaGhostBlock>(
+            RebarGhostBlockHolder.VanillaGhostBlock.KEY,
+        )
+
+        RebarEntity.register<ItemDisplay, RebarGhostBlockHolder.RebarGhostBlock>(
+            RebarGhostBlockHolder.RebarGhostBlock.KEY,
         )
 
         RebarEntity.register<ItemDisplay, FluidEndpointDisplay>(FluidEndpointDisplay.KEY)

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarEntityHolderBlock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarEntityHolderBlock.kt
@@ -83,6 +83,11 @@ interface RebarEntityHolderBlock {
     }
 
     @ApiStatus.NonExtendable
+    fun getHeldRebarEntity(name: String): RebarEntity<*>?
+            = getHeldEntityUuid(name)?.let { EntityStorage.get(it) }
+
+
+    @ApiStatus.NonExtendable
     fun <T: Entity> getHeldEntityOrThrow(clazz: Class<T>, name: String): T
             = getHeldEntity(clazz, name)
         ?: throw IllegalArgumentException("Entity $name does not exist or is not of type ${clazz.simpleName}")
@@ -186,7 +191,8 @@ interface RebarEntityHolderBlock {
 
         @EventHandler
         private fun onEntityRemove(event: EntityRemoveEvent) {
-            if (event.cause == EntityRemoveEvent.Cause.UNLOAD || event.cause == EntityRemoveEvent.Cause.PLAYER_QUIT) return
+            if (event.cause == EntityRemoveEvent.Cause.UNLOAD && event.entity.isPersistent) return
+            if (event.cause == EntityRemoveEvent.Cause.PLAYER_QUIT) return
             val blockPos = event.entity.persistentDataContainer.get(blockKey, RebarSerializers.BLOCK_POSITION) ?: return
             val block = BlockStorage.get(blockPos) as? RebarEntityHolderBlock ?: return
             holders[block]?.entries?.removeIf { it.value == event.entity.uniqueId }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarGhostBlockHolder.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarGhostBlockHolder.kt
@@ -1,0 +1,270 @@
+package io.github.pylonmc.rebar.block.base
+
+import io.github.pylonmc.rebar.Rebar
+import io.github.pylonmc.rebar.config.RebarConfig
+import io.github.pylonmc.rebar.datatypes.RebarSerializers
+import io.github.pylonmc.rebar.entity.EntityStorage
+import io.github.pylonmc.rebar.entity.RebarEntity
+import io.github.pylonmc.rebar.entity.display.BlockDisplayBuilder
+import io.github.pylonmc.rebar.entity.display.ItemDisplayBuilder
+import io.github.pylonmc.rebar.entity.display.transform.TransformBuilder
+import io.github.pylonmc.rebar.event.RebarBlockLoadEvent
+import io.github.pylonmc.rebar.registry.RebarRegistry
+import io.github.pylonmc.rebar.util.rebarKey
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.time.delay
+import org.bukkit.Color
+import org.bukkit.NamespacedKey
+import org.bukkit.block.Block
+import org.bukkit.block.data.BlockData
+import org.bukkit.entity.BlockDisplay
+import org.bukkit.entity.Entity
+import org.bukkit.entity.ItemDisplay
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.persistence.PersistentDataContainer
+import org.bukkit.util.Vector
+import org.joml.Vector3i
+import java.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * A wrapper over [RebarEntityHolderBlock] which allows for 'ghost blocks' (like those used
+ * to show how to build a multiblock) to be managed. Each ghost block has a relative position
+ * and can display vanilla blocks, rebar blocks, or both.
+ *
+ * Due to some annoying technicalities, vanilla blocks need to be displayed as a [BlockDisplay]
+ * and Rebar items as an [ItemDisplay]. So we operate a somewhat cursed system where either a
+ * BlockDisplay, ItemDisplay, or both are spawned. In the case where both are spawned, one of
+ * the displays is hidden while the other is shown as all the possible states are cycled
+ * through.
+ *
+ * You can access the individual displays with [getVanillaGhostBlockDisplay] and
+ * [getRebarGhostBlockDisplay]. Keep in mind that any given position may have none, one, or both
+ * displays.
+ */
+interface RebarGhostBlockHolder : RebarEntityHolderBlock {
+
+    open class GhostBlock<E: Entity> : RebarEntity<E> {
+        val position: Vector3i
+
+        constructor(entity: E) : super(entity) {
+            position = entity.persistentDataContainer.get(POSITION_KEY, RebarSerializers.VECTOR3I)!!
+        }
+
+        constructor(key: NamespacedKey, entity: E, position: Vector3i) : super(key, entity) {
+            this.position = position
+        }
+
+        override fun write(pdc: PersistentDataContainer) {
+            pdc.set(POSITION_KEY, RebarSerializers.VECTOR3I, position)
+        }
+
+        companion object {
+            val POSITION_KEY = rebarKey("ghost_block_block_position")
+        }
+    }
+
+    class VanillaGhostBlock : GhostBlock<BlockDisplay> {
+
+        val vanillaBlocks: MutableList<BlockData>
+
+        constructor(entity: BlockDisplay) : super(entity) {
+            vanillaBlocks = entity.persistentDataContainer.get(VANILLA_BLOCKS_KEY, VANILLA_BLOCKS_TYPE)!!
+        }
+
+        constructor(ghostBlockHolder: Block, position: Vector3i, blockDatas: MutableList<BlockData>) : super(
+            KEY,
+            BlockDisplayBuilder()
+                .blockData(blockDatas.first())
+                .glow(Color.WHITE)
+                .transformation(TransformBuilder().scale(0.501))
+                .build(ghostBlockHolder.location.toCenterLocation().add(Vector.fromJOML(position))),
+            position
+        ) {
+            this.vanillaBlocks = blockDatas
+        }
+
+        override fun write(pdc: PersistentDataContainer) {
+            pdc.set(VANILLA_BLOCKS_KEY, VANILLA_BLOCKS_TYPE, vanillaBlocks)
+        }
+
+        fun setSize(size: Double) {
+            entity.setTransformationMatrix(TransformBuilder().scale(size).buildForBlockDisplay())
+        }
+
+        fun setIndex(i: Int) {
+            entity.block = vanillaBlocks[i]
+        }
+
+        companion object {
+            val KEY = rebarKey("vanilla_ghost_block")
+            val VANILLA_BLOCKS_KEY = rebarKey("vanilla_ghost_block_vanilla_blocks")
+            val VANILLA_BLOCKS_TYPE = RebarSerializers.LIST.listTypeFrom(RebarSerializers.BLOCK_DATA)
+        }
+    }
+
+    class RebarGhostBlock : GhostBlock<ItemDisplay> {
+
+        val rebarBlocks: MutableList<NamespacedKey>
+
+        constructor(entity: ItemDisplay) : super(entity) {
+            rebarBlocks = entity.persistentDataContainer.get(REBAR_BLOCKS_KEY, VANILLA_BLOCKS_TYPE)!!
+        }
+
+        constructor(ghostBlockHolder: Block, position: Vector3i, items: MutableList<NamespacedKey>) : super(
+            KEY,
+            ItemDisplayBuilder()
+                .itemStack(RebarRegistry.ITEMS.getOrThrow(items.first()).getItemStack())
+                .glow(Color.WHITE)
+                .transformation(TransformBuilder().scale(0.501))
+                .build(ghostBlockHolder.location.toCenterLocation().add(Vector.fromJOML(position))),
+            position
+        ) {
+            this.rebarBlocks = items
+        }
+
+        override fun write(pdc: PersistentDataContainer) {
+            pdc.set(REBAR_BLOCKS_KEY, VANILLA_BLOCKS_TYPE, rebarBlocks)
+        }
+
+        fun setSize(size: Double) {
+            entity.setTransformationMatrix(TransformBuilder().scale(size).buildForItemDisplay())
+        }
+
+        fun setIndex(i: Int) {
+            entity.setItemStack(RebarRegistry.ITEMS.getOrThrow(rebarBlocks[i]).getItemStack())
+        }
+
+        companion object {
+            val KEY = rebarKey("rebar_ghost_block")
+            val REBAR_BLOCKS_KEY = rebarKey("rebar_ghost_block_rebar_blocks")
+            val VANILLA_BLOCKS_TYPE = RebarSerializers.LIST.listTypeFrom(RebarSerializers.NAMESPACED_KEY)
+        }
+    }
+
+    fun addGhostBlock(position: Vector3i, vanillaBlocks: List<BlockData>, rebarBlocks: List<NamespacedKey>) {
+        check(!hasGhostBlockAt(position)) { "There is already a ghost block at $position" }
+
+        if (!vanillaBlocks.isEmpty()) {
+            val entity = VanillaGhostBlock(block, position, vanillaBlocks.toMutableList())
+            EntityStorage.add(entity)
+            addEntity(getVanillaGhostBlockName(position), entity)
+        }
+
+        if (!rebarBlocks.isEmpty()) {
+            val entity = RebarGhostBlock(block, position, rebarBlocks.toMutableList())
+            EntityStorage.add(entity)
+            addEntity(getRebarGhostBlockName(position), entity)
+        }
+
+        startCycleTask(position)
+    }
+
+    fun removeGhostBlock(position: Vector3i) {
+        getHeldEntity(getVanillaGhostBlockName(position))?.remove()
+        getHeldEntity(getRebarGhostBlockName(position))?.remove()
+    }
+
+    fun hasGhostBlockAt(position: Vector3i)
+            = getHeldEntity(getVanillaGhostBlockName(position)) != null
+            || getHeldEntity(getRebarGhostBlockName(position)) != null
+
+    fun getVanillaGhostBlockDisplay(position: Vector3i)
+            = getHeldRebarEntity(VanillaGhostBlock::class.java, getVanillaGhostBlockName(position))
+
+    fun getRebarGhostBlockDisplay(position: Vector3i)
+            = getHeldRebarEntity(RebarGhostBlock::class.java, getRebarGhostBlockName(position))
+
+    private fun startCycleTask(position: Vector3i) {
+        val vanillaGhostBlock = getVanillaGhostBlockDisplay(position)
+        val rebarGhostBlock = getRebarGhostBlockDisplay(position)
+        check(vanillaGhostBlock != null || rebarGhostBlock != null)
+
+        val updateTasks = mutableListOf<Runnable>()
+        if (vanillaGhostBlock != null) {
+            for (i in 0..<vanillaGhostBlock.vanillaBlocks.size) {
+                if (i == 0 && rebarGhostBlock != null) {
+                    updateTasks.add {
+                        rebarGhostBlock.entity.setTransformationMatrix(TransformBuilder().scale(0.499).buildForItemDisplay())
+                        vanillaGhostBlock.entity.setTransformationMatrix(TransformBuilder().scale(0.501).buildForBlockDisplay())
+                        vanillaGhostBlock.setIndex(i)
+                    }
+                } else {
+                    updateTasks.add {
+                        vanillaGhostBlock.setIndex(i)
+                    }
+                }
+            }
+        }
+        if (rebarGhostBlock != null) {
+            for (i in 0..<rebarGhostBlock.rebarBlocks.size) {
+                if (i == 0 && vanillaGhostBlock != null) {
+                    updateTasks.add {
+                        vanillaGhostBlock.setSize(0.499)
+                        rebarGhostBlock.setSize(0.501)
+                        rebarGhostBlock.setIndex(i)
+                    }
+                } else {
+                    updateTasks.add {
+                        rebarGhostBlock.setIndex(i)
+                    }
+                }
+            }
+        }
+
+        if (updateTasks.size <= 1) {
+            return
+        }
+
+        var i = 0
+        Rebar.scope.launch(Rebar.mainThreadDispatcher) {
+            while (true) {
+                if (vanillaGhostBlock != null && !vanillaGhostBlock.entity.isValid
+                    || rebarGhostBlock != null && !rebarGhostBlock.entity.isValid
+                ) {
+                    break
+                }
+
+                updateTasks[i].run()
+                i++
+                i %= updateTasks.size
+
+                delay(Duration.ofMillis((RebarConfig.GHOST_BLOCK_TICK_INTERVAL * 1000 / 20).toLong()))
+            }
+        }
+    }
+
+    companion object : Listener {
+
+        @EventHandler(priority = EventPriority.MONITOR)
+        fun onLoad(event: RebarBlockLoadEvent) {
+            val block = event.rebarBlock
+            if (block !is RebarGhostBlockHolder) {
+                return
+            }
+
+            for (name in block.heldEntities.keys) {
+                val entity = block.getHeldRebarEntity(name)
+                if (entity !is GhostBlock) {
+                    continue
+                }
+                val vanilla = block.getHeldRebarEntity(VanillaGhostBlock::class.java, getVanillaGhostBlockName(entity.position))
+                val rebar = block.getHeldRebarEntity(RebarGhostBlock::class.java, getRebarGhostBlockName(entity.position))
+                if (vanilla != null && rebar != null) {
+                    if (entity is VanillaGhostBlock) { // avoid starting duplicate tasks
+                        block.startCycleTask(entity.position)
+                    }
+                } else {
+                    block.startCycleTask(entity.position)
+                }
+            }
+        }
+
+        private fun getVanillaGhostBlockName(position: Vector3i) = "vanilla_ghost_block_${position.x}_${position.y}_${position.z}"
+
+        private fun getRebarGhostBlockName(position: Vector3i) = "rebar_ghost_block_${position.x}_${position.y}_${position.z}"
+    }
+}

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarMultiblock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarMultiblock.kt
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.ApiStatus
  * are loaded).
  *
  * @see RebarSimpleMultiblock
+ * @see RebarGhostBlockHolder
  */
 interface RebarMultiblock {
     // This is automatically implemented by RebarBlock (lol)

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarSimpleMultiblock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarSimpleMultiblock.kt
@@ -1,22 +1,11 @@
 package io.github.pylonmc.rebar.block.base
 
-import io.github.pylonmc.rebar.Rebar
 import io.github.pylonmc.rebar.block.BlockStorage
-import io.github.pylonmc.rebar.block.MultiblockCache
-import io.github.pylonmc.rebar.block.RebarBlock
-import io.github.pylonmc.rebar.block.RebarBlockSchema
 import io.github.pylonmc.rebar.datatypes.RebarSerializers
-import io.github.pylonmc.rebar.entity.EntityStorage
-import io.github.pylonmc.rebar.entity.RebarEntity
-import io.github.pylonmc.rebar.entity.display.BlockDisplayBuilder
-import io.github.pylonmc.rebar.entity.display.ItemDisplayBuilder
-import io.github.pylonmc.rebar.entity.display.transform.TransformBuilder
 import io.github.pylonmc.rebar.event.RebarBlockDeserializeEvent
 import io.github.pylonmc.rebar.event.RebarBlockPlaceEvent
 import io.github.pylonmc.rebar.event.RebarBlockSerializeEvent
 import io.github.pylonmc.rebar.event.RebarBlockUnloadEvent
-import io.github.pylonmc.rebar.item.builder.ItemStackBuilder
-import io.github.pylonmc.rebar.registry.RebarRegistry
 import io.github.pylonmc.rebar.util.getRelative
 import io.github.pylonmc.rebar.util.position.ChunkPosition
 import io.github.pylonmc.rebar.util.position.position
@@ -24,31 +13,22 @@ import io.github.pylonmc.rebar.util.rebarKey
 import io.github.pylonmc.rebar.util.rotateVectorToFace
 import io.github.pylonmc.rebar.waila.Waila
 import io.github.pylonmc.rebar.waila.WailaDisplay
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import net.kyori.adventure.text.Component
 import org.bukkit.Color
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
 import org.bukkit.block.Block
 import org.bukkit.block.BlockFace
 import org.bukkit.block.data.BlockData
-import org.bukkit.entity.BlockDisplay
-import org.bukkit.entity.Display
-import org.bukkit.entity.ItemDisplay
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
-import org.bukkit.persistence.PersistentDataContainer
 import org.bukkit.util.Vector
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.annotations.MustBeInvokedByOverriders
 import org.joml.Vector3i
-import java.util.IdentityHashMap
-import java.util.UUID
+import java.util.*
 import kotlin.math.abs
 import kotlin.math.min
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * A multiblock that is made of a predefined set of components.
@@ -60,34 +40,29 @@ import kotlin.time.Duration.Companion.seconds
  * If you need something more flexible (eg: a fluid tank that can have up to 10
  * fluid casings added to increase the capacity), see [RebarMultiblock].
  */
-interface RebarSimpleMultiblock : RebarMultiblock, RebarEntityHolderBlock, RebarEntityCulledBlock {
-
-    /**
-     * Implement this together with [MultiblockComponent], it is used to spawn a single entity
-     * to display the needs of a single multiblock requirement
-     *
-     * You must implement either this or [MultipleGhostBlocks], together with [MultiblockComponent] for a correct implementation
-     */
-    interface SingleGhostBlock {
-        fun spawnGhostBlock(block: Block): UUID
-    }
-
-    /**
-     * Implement this together with [MultiblockComponent], it is used to spawn multiple entities
-     * to display the needs of a single multiblock requirement, you are going to need this only when
-     * you can't display a block requirement with only a single [ItemDisplay] or [BlockDisplay]
-     *
-     * You must implement either this or [SingleGhostBlock], together with [MultiblockComponent] for a correct implementation
-     */
-    interface MultipleGhostBlocks {
-        fun spawnGhostBlocks(block: Block): List<UUID>
-    }
+interface RebarSimpleMultiblock : RebarMultiblock, RebarGhostBlockHolder, RebarEntityCulledBlock {
 
     /**
      * Represents a single block of a multiblock.
      */
-    interface MultiblockComponent {
-        fun matches(block: Block): Boolean
+    open class MultiblockComponent protected constructor(
+        val vanillaBlocks: List<BlockData>,
+        val rebarBlocks: List<NamespacedKey>,
+    ) {
+
+        init {
+            check(!vanillaBlocks.isEmpty() || !rebarBlocks.isEmpty()) {
+                "Multiblock component does not match anything"
+            }
+        }
+
+        fun matches(block: Block): Boolean {
+            val rebarBlock = BlockStorage.get(block)
+            if (rebarBlock != null) {
+                return rebarBlock.key in rebarBlocks
+            }
+            return vanillaBlocks.any { block.blockData.matches(it) }
+        }
 
         /**
          * Sets [block] to a 'default' value which matches this MultiblockComponent.
@@ -95,307 +70,68 @@ interface RebarSimpleMultiblock : RebarMultiblock, RebarEntityHolderBlock, Rebar
          * For example, if a MultiblockComponent can be grass or dirt, this should set
          * the block to either grass or dirt
          */
-        fun placeDefaultBlock(block: Block)
+        fun placeDefaultBlock(block: Block) {
+            if (!block.type.isAir || BlockStorage.isRebarBlock(block)) {
+                return
+            }
+
+            if (!vanillaBlocks.isEmpty()) {
+                block.blockData = vanillaBlocks.first().clone()
+            } else {
+                BlockStorage.placeBlock(block, rebarBlocks.first())
+            }
+        }
+
+        /**
+         * Spawns the ghost block that visualises this component
+         *
+         * @see RebarGhostBlockHolder
+         */
+        fun spawnGhostBlock(multiblock: RebarSimpleMultiblock, rotatedPosition: Vector3i) {
+            multiblock.addGhostBlock(rotatedPosition, vanillaBlocks, rebarBlocks)
+            updateGhostBlock(multiblock, rotatedPosition)
+        }
+
+        /**
+         * Updates the corresponding ghost block's visuals
+         */
+        fun updateGhostBlock(multiblock: RebarSimpleMultiblock, rotatedPosition: Vector3i) {
+            val block = multiblock.block.getRelative(rotatedPosition)
+            val color = if (matches(block)) {
+                Color.LIME
+            } else if (block.isEmpty && !BlockStorage.isRebarBlock(block)) {
+                Color.ORANGE
+            } else {
+                Color.RED
+            }
+            multiblock.getVanillaGhostBlockDisplay(rotatedPosition)?.entity?.glowColorOverride = color
+            multiblock.getRebarGhostBlockDisplay(rotatedPosition)?.entity?.glowColorOverride = color
+        }
 
         companion object {
 
             @JvmStatic
-            fun of(material: Material) = VanillaMultiblockComponent(material)
+            fun of(blockDatas: List<BlockData>, rebarItems: List<NamespacedKey>) = MultiblockComponent(
+                blockDatas, rebarItems
+            )
 
             @JvmStatic
-            fun of(key: NamespacedKey) = RebarMultiblockComponent(key)
+            fun of(vararg materials: Material) = MultiblockComponent(
+                materials.map { it.createBlockData() }, listOf()
+            )
+
+            @JvmStatic
+            fun of(vararg blockDatas: BlockData) = MultiblockComponent(
+                blockDatas.toList(), listOf()
+            )
+
+            @JvmStatic
+            fun of(vararg keys: NamespacedKey) = MultiblockComponent(
+                listOf(), keys.toList()
+            )
         }
     }
 
-    interface MultiblockComponentBlockDisplay {
-        fun blockDataList() : List<BlockData>
-    }
-
-    /**
-     * A block display that represents this block, showing the player what block
-     * needs to be placed in a specific location.
-     */
-    class MultiblockGhostBlock(entity: Display, val displayName: Component) :
-        RebarEntity<Display>(KEY, entity) {
-
-        constructor(entity: Display, displayName: String)
-                : this(entity, Component.text(displayName))
-
-        constructor(entity: Display)
-                : this(entity, entity.persistentDataContainer.get(NAME_KEY, RebarSerializers.COMPONENT)!!)
-
-        override fun getWaila(player: Player): WailaDisplay {
-            return WailaDisplay(displayName)
-        }
-
-        override fun write(pdc: PersistentDataContainer) {
-            pdc.set(NAME_KEY, RebarSerializers.COMPONENT, displayName)
-        }
-
-        companion object {
-            val KEY = rebarKey("multiblock_ghost_block")
-            val NAME_KEY = rebarKey("display_name")
-        }
-    }
-
-    /**
-     * Represents a vanilla component of a multiblock, which can have one or more materials.
-     *
-     * If multiple materials are specified, the ghost block will automatically cycle through all
-     * the given materials in order.
-     */
-    @JvmRecord
-    data class VanillaMultiblockComponent(val materials: List<Material>) : SingleGhostBlock, MultiblockComponent, MultiblockComponentBlockDisplay {
-
-        constructor(first: Material, vararg materials: Material) : this(listOf(first) + materials)
-
-        init {
-            check(materials.isNotEmpty()) { "Materials list cannot be empty" }
-        }
-
-        override fun matches(block: Block): Boolean = !BlockStorage.isRebarBlock(block) && block.type in materials
-
-        override fun placeDefaultBlock(block: Block) {
-            if (block.type.isAir && !BlockStorage.isRebarBlock(block)) {
-                block.type = materials.first()
-            }
-        }
-
-        override fun spawnGhostBlock(block: Block): UUID {
-            val blockDataList = blockDataList()
-            val display = BlockDisplayBuilder()
-                .material(materials.first())
-                .glow(Color.WHITE)
-                .transformation(TransformBuilder().scale(0.5))
-                .displayWidth(0.5f)
-                .displayHeight(0.5f)
-                .build(block.location.toCenterLocation())
-            EntityStorage.add(MultiblockGhostBlock(display, materials.joinToString(", ") { it.key.toString() }))
-
-            if (materials.size > 1) {
-                Rebar.scope.launch(Rebar.mainThreadDispatcher) {
-                    var i = 0
-                    while (display.isValid) {
-                        display.block = blockDataList[i]
-                        i++
-                        i %= materials.size
-                        delay(1.seconds)
-                    }
-                }
-            }
-
-            return display.uniqueId
-        }
-
-        override fun blockDataList(): List<BlockData> = materials.map { it.createBlockData() }
-    }
-
-    /**
-     * Represents a vanilla component of a multiblock, which can have one or more blockdatas.
-     *
-     * If multiple blockdatas are specified, the ghost block will automatically cycle through all
-     * the given blockdatas in order.
-     *
-     * This should be used only when you want to impose some constraints about the blockdata, for instance:
-     *
-     * <pre>{@code
-     * BlockData data = Material.CAMPFIRE.createBlockData("[lit=true]") // requires the campfire to be lit
-     * new VanillaBlockdataMultiblockComponent(data);
-     *
-     * // or if you prefer
-     * Campfire fire = (Campfire) Material.CAMPFIRE.createBlockData();
-     * fire.setLit(true);
-     * new VanillaBlockdataMultiblockComponent(fire);
-     * }
-     * </pre>
-     *
-     */
-    @JvmRecord
-    data class VanillaBlockdataMultiblockComponent(val blockDatas: List<BlockData>) : SingleGhostBlock, MultiblockComponent, MultiblockComponentBlockDisplay {
-
-        constructor(first: BlockData, vararg materials: BlockData) : this(listOf(first) + materials)
-
-        init {
-            check(blockDatas.isNotEmpty()) { "BlockData list cannot be empty" }
-        }
-
-        override fun matches(block: Block): Boolean {
-            if (BlockStorage.isRebarBlock(block)) return false
-            for (blockData in blockDatas) {
-                // IMPORTANT, a.matches(b) != b.matches(a), if you invert this check, kaboom
-                if (block.blockData.matches(blockData)) return true
-            }
-
-            return false
-        }
-
-        override fun placeDefaultBlock(block: Block) {
-            if (block.type.isAir && !BlockStorage.isRebarBlock(block)) {
-                block.blockData = blockDatas.first()
-            }
-        }
-
-        override fun spawnGhostBlock(block: Block): UUID {
-            val stringDatas: List<String> = blockDatas.map { it.getAsString(true) }
-            val display = BlockDisplayBuilder()
-                .material(blockDatas.first().material)
-                .glow(Color.WHITE)
-                .transformation(TransformBuilder().scale(0.5))
-                .build(block.location.toCenterLocation())
-            EntityStorage.add(MultiblockGhostBlock(display, stringDatas.joinToString(", ")))
-
-            if (blockDatas.size > 1) {
-                Rebar.scope.launch(Rebar.mainThreadDispatcher) {
-                    var i = 0
-                    while (display.isValid) {
-                        display.block = blockDatas[i]
-                        i++
-                        i %= blockDatas.size
-                        delay(1.seconds)
-                    }
-                }
-            }
-
-            return display.uniqueId
-        }
-
-        override fun blockDataList(): List<BlockData> = blockDatas
-    }
-
-    /**
-     * Displays all kind of MultiblockComponents that implement [MultiblockComponentBlockDisplay], together with
-     * special item handling for [RebarMultiblockComponent]
-     */
-    class MixedMultiblockComponent : MultiblockComponent, MultipleGhostBlocks {
-        val multiblockComponents: Collection<MultiblockComponent>
-
-        constructor(multiblockComponents: Collection<MultiblockComponent>) {
-            this.multiblockComponents = multiblockComponents
-        }
-
-        constructor(vararg validators: MultiblockComponent) : this(validators.toList())
-
-        override fun matches(block: Block): Boolean {
-            for (validator in multiblockComponents) {
-                if (validator.matches(block)) {
-                    return true
-                }
-            }
-
-            return false
-        }
-
-        override fun placeDefaultBlock(block: Block) {
-            multiblockComponents.first().placeDefaultBlock(block)
-        }
-
-        override fun spawnGhostBlocks(block: Block): List<UUID> {
-            var blockDisplay: BlockDisplay? = null
-            var itemDisplay: ItemDisplay? = null
-
-            val displayUpdates: MutableList<Runnable> = mutableListOf()
-            var name = ""
-            for (component in multiblockComponents) {
-                if (component is MultiblockComponentBlockDisplay) {
-                    val blockDatas = component.blockDataList()
-                    if (blockDisplay == null) {
-                        blockDisplay = BlockDisplayBuilder()
-                            .material(blockDatas.first().material)
-                            .glow(Color.WHITE)
-                            .transformation(TransformBuilder().scale(0.5))
-                            .build(block.location.toCenterLocation())
-                    }
-
-                    for (blockData in blockDatas) {
-                        displayUpdates.add {
-                            blockDisplay.isVisibleByDefault = true
-                            itemDisplay?.isVisibleByDefault = false
-                            blockDisplay.block = blockData
-                        }
-
-                        name += blockData.getAsString(true) + ", "
-                    }
-                } else if (component is RebarMultiblockComponent) {
-                    val key = component.key
-                    val schema = component.schema()
-                    val itemBuilder = ItemStackBuilder.of(schema.material).addCustomModelDataString(key.toString())
-                    if (itemDisplay == null) {
-                        itemDisplay = ItemDisplayBuilder()
-                            .itemStack(itemBuilder)
-                            .glow(Color.WHITE)
-                            .transformation(TransformBuilder().scale(0.5))
-                            .build(block.location.toCenterLocation())
-                    }
-
-                    displayUpdates.add {
-                        itemDisplay.isVisibleByDefault = true
-                        blockDisplay?.isVisibleByDefault = false
-                        itemDisplay.setItemStack(
-                            itemBuilder.build()
-                        )
-                    }
-
-                    name += "$key, "
-                }
-            }
-
-            blockDisplay?.let {
-                EntityStorage.add(MultiblockGhostBlock(it, name))
-            }
-
-            itemDisplay?.let {
-                EntityStorage.add(MultiblockGhostBlock(it, name))
-            }
-
-            if (displayUpdates.size > 1) {
-                Rebar.scope.launch(Rebar.mainThreadDispatcher) {
-                    var i = 0
-                    while (itemDisplay?.isValid ?: true && blockDisplay?.isValid ?: true) {
-                        displayUpdates[i].run()
-                        i++
-                        i %= displayUpdates.size
-                        delay(1.seconds)
-                    }
-                }
-            }
-
-            val mutableList = mutableListOf<UUID>()
-            blockDisplay?.let { mutableList.add(it.uniqueId) }
-            itemDisplay?.let { mutableList.add(it.uniqueId) }
-
-            return mutableList
-        }
-    }
-
-    /**
-     * Represents a Rebar block component of a multiblock.
-     */
-    @JvmRecord
-    data class RebarMultiblockComponent(val key: NamespacedKey) : SingleGhostBlock, MultiblockComponent {
-        fun schema() : RebarBlockSchema = RebarRegistry.BLOCKS[key]
-            ?: throw IllegalArgumentException("Block schema $key does not exist")
-
-        override fun matches(block: Block): Boolean = BlockStorage.get(block)?.schema?.key == key
-
-        override fun placeDefaultBlock(block: Block) {
-            if (block.type.isAir && !BlockStorage.isRebarBlock(block)) {
-                BlockStorage.placeBlock(block, key)
-            }
-        }
-
-        override fun spawnGhostBlock(block: Block): UUID {
-            val schema = schema()
-            val display = ItemDisplayBuilder()
-                .itemStack(ItemStackBuilder.of(schema.material).addCustomModelDataString(key.toString()))
-                .glow(Color.WHITE)
-                .transformation(TransformBuilder().scale(0.5))
-                .build(block.location.toCenterLocation())
-            EntityStorage.add(MultiblockGhostBlock(display, key.toString()))
-            return display.uniqueId
-        }
-    }
-
-    @get:ApiStatus.NonExtendable
     private val simpleMultiblockData: SimpleMultiblockData
         get() = simpleMultiblocks.getOrPut(this) { SimpleMultiblockData(null) }
 
@@ -447,38 +183,6 @@ interface RebarSimpleMultiblock : RebarMultiblock, RebarEntityHolderBlock, Rebar
         }
     }
 
-    /**
-     * Spawns a ghost block for every component of the multiblock.
-     */
-    @ApiStatus.Internal
-    fun spawnGhostBlocks() {
-        val block = (this as RebarBlock).block
-        val facing = simpleMultiblockData.direction
-        val rotatedComponents = if (facing == null) components else rotateComponentsToFace(components, facing)
-        for ((offset, component) in rotatedComponents) {
-            val startSection = "multiblock_ghost_block_${offset.x}_${offset.y}_${offset.z}"
-
-            if (component is SingleGhostBlock) {
-                if (!isHeldEntityPresent(startSection)) {
-                    val ghostBlock = component.spawnGhostBlock((block.position + offset).block)
-                    heldEntities[startSection] = ghostBlock
-                }
-            } else if (component is MultipleGhostBlocks) {
-                if (!heldEntities.keys.any { it.startsWith(startSection) }) {
-                    val ghostBlocks = component.spawnGhostBlocks((block.position + offset).block)
-
-                    var i = 0
-                    ghostBlocks.forEach { ghostBlock ->
-                        val key = "${startSection}_$i"
-                        i++
-                        heldEntities[key] = ghostBlock
-                    }
-                }
-            }
-        }
-        updateGhostBlockColors()
-    }
-
     // Just assumes any rotation of the multiblock is valid, probably not worth the extra logic to account for
     // different facing directions.
     /**
@@ -506,12 +210,15 @@ interface RebarSimpleMultiblock : RebarMultiblock, RebarEntityHolderBlock, Rebar
     val maxCorner: Vector3i
         get() = Vector3i(horizontalRadius, components.keys.maxOf { it.y }, horizontalRadius)
 
-    fun getMultiblockBlock(position: Vector3i): Block {
+    fun getMultiblockBlock(position: Vector3i)
+        = block.getRelative(getRotatedPosition(position))
+
+    fun getRotatedPosition(rotatedPosition: Vector3i): Vector3i {
         val direction = getMultiblockDirection()
         return if (direction != null) {
-            block.getRelative(rotateVectorToFace(position, direction))
+            rotateVectorToFace(rotatedPosition, direction)
         } else {
-            block.getRelative(position)
+            rotatedPosition
         }
     }
 
@@ -549,17 +256,17 @@ interface RebarSimpleMultiblock : RebarMultiblock, RebarEntityHolderBlock, Rebar
             }
         }
 
-        updateGhostBlockColors()
+        for ((position, component) in components) {
+            component.updateGhostBlock(this, getRotatedPosition(position))
+        }
 
         return formed
     }
 
     @MustBeInvokedByOverriders
     override fun onMultiblockFormed() {
-        val toRemove = heldEntities.keys.filter { it.startsWith("multiblock_ghost_block_") }
-        for (key in toRemove) {
-            EntityStorage.get(heldEntities[key]!!)!!.entity.remove()
-            heldEntities.remove(key)
+        for ((position, _) in components) {
+            removeGhostBlock(getRotatedPosition(position))
         }
         for (position in components.keys) {
             Waila.addWailaOverride(getMultiblockBlock(position), this::getWaila)
@@ -569,7 +276,9 @@ interface RebarSimpleMultiblock : RebarMultiblock, RebarEntityHolderBlock, Rebar
     @MustBeInvokedByOverriders
     override fun onMultiblockUnformed(partUnloaded: Boolean) {
         if (!partUnloaded) {
-            spawnGhostBlocks()
+            for ((position, component) in components) {
+                component.spawnGhostBlock(this, getRotatedPosition(position))
+            }
         }
         for (position in components.keys) {
             Waila.removeWailaOverride(getMultiblockBlock(position))
@@ -582,51 +291,6 @@ interface RebarSimpleMultiblock : RebarMultiblock, RebarEntityHolderBlock, Rebar
 
     override val culledEntityIds: Iterable<UUID>
         get() = heldEntities.values
-
-    /**
-     * Updates the color of all ghost blocks to indicate whether the block is correctly placed.
-     */
-    @ApiStatus.Internal
-    fun updateGhostBlockColors() {
-        if (MultiblockCache.isFormed(this)) {
-            return // ghosts should have been deleted
-        }
-
-        val block = (this as RebarBlock).block
-        val facing = simpleMultiblockData.direction
-        val rotatedComponents = if (facing == null) components else rotateComponentsToFace(components, facing)
-        for ((offset, component) in rotatedComponents) {
-            val mainKey = "multiblock_ghost_block_${offset.x}_${offset.y}_${offset.z}"
-            val entity = getHeldRebarEntity(
-                MultiblockGhostBlock::class.java,
-                "multiblock_ghost_block_${offset.x}_${offset.y}_${offset.z}"
-            )
-            if (entity != null) {
-                entity.entity.glowColorOverride = if (component.matches((block.position + offset).block)) {
-                    Color.GREEN
-                } else {
-                    Color.RED
-                }
-            } else {
-                for (entry in heldEntities.entries) {
-                    if (!entry.key.startsWith(mainKey)) continue
-
-                    val entityEntry = getHeldRebarEntity(
-                        MultiblockGhostBlock::class.java,
-                        entry.key
-                    )
-
-                    if (entityEntry == null) continue
-
-                    entityEntry.entity.glowColorOverride = if (component.matches((block.position + offset).block)) {
-                        Color.GREEN
-                    } else {
-                        Color.RED
-                    }
-                }
-            }
-        }
-    }
 
     @ApiStatus.Internal
     companion object : Listener {
@@ -641,7 +305,9 @@ interface RebarSimpleMultiblock : RebarMultiblock, RebarEntityHolderBlock, Rebar
         private fun onPlace(event: RebarBlockPlaceEvent) {
             val block = event.rebarBlock
             if (block !is RebarSimpleMultiblock) return
-            block.spawnGhostBlocks()
+            for ((position, component) in block.components) {
+                component.spawnGhostBlock(block, block.getRotatedPosition(position))
+            }
         }
 
         @EventHandler

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarSimpleMultiblock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/base/RebarSimpleMultiblock.kt
@@ -16,6 +16,7 @@ import io.github.pylonmc.rebar.waila.WailaDisplay
 import org.bukkit.Color
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
+import org.bukkit.Registry
 import org.bukkit.block.Block
 import org.bukkit.block.BlockFace
 import org.bukkit.block.data.BlockData
@@ -125,10 +126,16 @@ interface RebarSimpleMultiblock : RebarMultiblock, RebarGhostBlockHolder, RebarE
                 blockDatas.toList(), listOf()
             )
 
+            /**
+             * Accepts vanilla keys (`minecraft:grass`) or Rebar keys (`pylon:copper_sheet`)
+             */
             @JvmStatic
-            fun of(vararg keys: NamespacedKey) = MultiblockComponent(
-                listOf(), keys.toList()
-            )
+            fun of(vararg keys: NamespacedKey): MultiblockComponent {
+                val vanilla = keys.filter { it.asString().startsWith("minecraft") }
+                    .map { Registry.MATERIAL.getOrThrow(it).createBlockData() }
+                val rebar = keys.filter { !it.asString().startsWith("minecraft") }
+                return MultiblockComponent(vanilla, rebar)
+            }
         }
     }
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/config/RebarConfig.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/config/RebarConfig.kt
@@ -60,6 +60,9 @@ object RebarConfig {
     @JvmField
     val CARGO_TRANSFER_RATE_MULTIPLIER = config.getOrThrow("cargo-transfer-rate-multiplier", ConfigAdapter.INTEGER)
 
+    @JvmField
+    val GHOST_BLOCK_TICK_INTERVAL = config.getOrThrow("ghost-block-tick-interval", ConfigAdapter.INTEGER)
+
     object ResearchConfig {
 
         @JvmField

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/datatypes/BlockDataPersistentDataType.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/datatypes/BlockDataPersistentDataType.kt
@@ -1,0 +1,24 @@
+package io.github.pylonmc.rebar.datatypes
+
+import org.bukkit.Bukkit
+import org.bukkit.block.data.BlockData
+import org.bukkit.persistence.PersistentDataAdapterContext
+import org.bukkit.persistence.PersistentDataType
+
+object BlockDataPersistentDataType : PersistentDataType<String, BlockData> {
+
+    override fun getPrimitiveType(): Class<String> = String::class.java
+
+    override fun getComplexType(): Class<BlockData> = BlockData::class.java
+
+    override fun fromPrimitive(
+        primitive: String,
+        context: PersistentDataAdapterContext
+    ): BlockData {
+        return Bukkit.createBlockData(primitive)
+    }
+
+    override fun toPrimitive(complex: BlockData, context: PersistentDataAdapterContext): String {
+        return complex.asString
+    }
+}

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/datatypes/RebarSerializers.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/datatypes/RebarSerializers.kt
@@ -75,6 +75,15 @@ object RebarSerializers {
     val VECTOR = VectorPersistentDataType
 
     @JvmField
+    val VECTOR3I = Vector3iPersistentDataType
+
+    @JvmField
+    val VECTOR3F = Vector3fPersistentDataType
+
+    @JvmField
+    val VECTOR3D = Vector3dPersistentDataType
+
+    @JvmField
     val WORLD = WorldPersistentDataType
 
     @JvmField
@@ -110,6 +119,9 @@ object RebarSerializers {
 
     @JvmField
     val MATERIAL = KEYED.keyedTypeFrom<Material>(Registry.MATERIAL::getOrThrow)
+
+    @JvmField
+    val BLOCK_DATA = BlockDataPersistentDataType
 
     @JvmField
     val REBAR_FLUID = KEYED.keyedTypeFrom<RebarFluid>(RebarRegistry.FLUIDS::getOrThrow)

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/datatypes/Vector3dPersistentDataType.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/datatypes/Vector3dPersistentDataType.kt
@@ -1,0 +1,32 @@
+package io.github.pylonmc.rebar.datatypes
+
+import io.github.pylonmc.rebar.util.rebarKey
+import org.bukkit.persistence.PersistentDataAdapterContext
+import org.bukkit.persistence.PersistentDataContainer
+import org.bukkit.persistence.PersistentDataType
+import org.joml.Vector3d
+
+object Vector3dPersistentDataType : PersistentDataType<PersistentDataContainer, Vector3d> {
+    val xKey = rebarKey("x")
+    val yKey = rebarKey("y")
+    val zKey = rebarKey("z")
+
+    override fun getPrimitiveType(): Class<PersistentDataContainer> = PersistentDataContainer::class.java
+
+    override fun getComplexType(): Class<Vector3d> = Vector3d::class.java
+
+    override fun fromPrimitive(primitive: PersistentDataContainer, context: PersistentDataAdapterContext): Vector3d {
+        val x = primitive.get(xKey, RebarSerializers.DOUBLE)!!
+        val y = primitive.get(yKey, RebarSerializers.DOUBLE)!!
+        val z = primitive.get(zKey, RebarSerializers.DOUBLE)!!
+        return Vector3d(x, y, z)
+    }
+
+    override fun toPrimitive(complex: Vector3d, context: PersistentDataAdapterContext): PersistentDataContainer {
+        val pdc = context.newPersistentDataContainer()
+        pdc.set(xKey, RebarSerializers.DOUBLE, complex.x)
+        pdc.set(yKey, RebarSerializers.DOUBLE, complex.y)
+        pdc.set(zKey, RebarSerializers.DOUBLE, complex.z)
+        return pdc
+    }
+}

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/datatypes/Vector3fPersistentDataType.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/datatypes/Vector3fPersistentDataType.kt
@@ -1,0 +1,32 @@
+package io.github.pylonmc.rebar.datatypes
+
+import io.github.pylonmc.rebar.util.rebarKey
+import org.bukkit.persistence.PersistentDataAdapterContext
+import org.bukkit.persistence.PersistentDataContainer
+import org.bukkit.persistence.PersistentDataType
+import org.joml.Vector3f
+
+object Vector3fPersistentDataType : PersistentDataType<PersistentDataContainer, Vector3f> {
+    val xKey = rebarKey("x")
+    val yKey = rebarKey("y")
+    val zKey = rebarKey("z")
+
+    override fun getPrimitiveType(): Class<PersistentDataContainer> = PersistentDataContainer::class.java
+
+    override fun getComplexType(): Class<Vector3f> = Vector3f::class.java
+
+    override fun fromPrimitive(primitive: PersistentDataContainer, context: PersistentDataAdapterContext): Vector3f {
+        val x = primitive.get(xKey, RebarSerializers.FLOAT)!!
+        val y = primitive.get(yKey, RebarSerializers.FLOAT)!!
+        val z = primitive.get(zKey, RebarSerializers.FLOAT)!!
+        return Vector3f(x, y, z)
+    }
+
+    override fun toPrimitive(complex: Vector3f, context: PersistentDataAdapterContext): PersistentDataContainer {
+        val pdc = context.newPersistentDataContainer()
+        pdc.set(xKey, RebarSerializers.FLOAT, complex.x)
+        pdc.set(yKey, RebarSerializers.FLOAT, complex.y)
+        pdc.set(zKey, RebarSerializers.FLOAT, complex.z)
+        return pdc
+    }
+}

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/datatypes/Vector3iPersistentDataType.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/datatypes/Vector3iPersistentDataType.kt
@@ -1,0 +1,32 @@
+package io.github.pylonmc.rebar.datatypes
+
+import io.github.pylonmc.rebar.util.rebarKey
+import org.bukkit.persistence.PersistentDataAdapterContext
+import org.bukkit.persistence.PersistentDataContainer
+import org.bukkit.persistence.PersistentDataType
+import org.joml.Vector3i
+
+object Vector3iPersistentDataType : PersistentDataType<PersistentDataContainer, Vector3i> {
+    val xKey = rebarKey("x")
+    val yKey = rebarKey("y")
+    val zKey = rebarKey("z")
+
+    override fun getPrimitiveType(): Class<PersistentDataContainer> = PersistentDataContainer::class.java
+
+    override fun getComplexType(): Class<Vector3i> = Vector3i::class.java
+
+    override fun fromPrimitive(primitive: PersistentDataContainer, context: PersistentDataAdapterContext): Vector3i {
+        val x = primitive.get(xKey, RebarSerializers.INTEGER)!!
+        val y = primitive.get(yKey, RebarSerializers.INTEGER)!!
+        val z = primitive.get(zKey, RebarSerializers.INTEGER)!!
+        return Vector3i(x, y, z)
+    }
+
+    override fun toPrimitive(complex: Vector3i, context: PersistentDataAdapterContext): PersistentDataContainer {
+        val pdc = context.newPersistentDataContainer()
+        pdc.set(xKey, RebarSerializers.INTEGER, complex.x)
+        pdc.set(yKey, RebarSerializers.INTEGER, complex.y)
+        pdc.set(zKey, RebarSerializers.INTEGER, complex.z)
+        return pdc
+    }
+}

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/display/BlockDisplayBuilder.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/display/BlockDisplayBuilder.kt
@@ -23,6 +23,7 @@ open class BlockDisplayBuilder() {
     protected var interpolationDuration: Int? = null
     protected var displayWidth: Float? = null
     protected var displayHeight: Float? = null
+    protected var persistent: Boolean? = null
 
     constructor(other: BlockDisplayBuilder): this() {
         this.material = other.material
@@ -35,6 +36,7 @@ open class BlockDisplayBuilder() {
         this.interpolationDuration = other.interpolationDuration
         this.displayWidth = other.displayWidth
         this.displayHeight = other.displayHeight
+        this.persistent = other.persistent
     }
 
     fun material(material: Material?): BlockDisplayBuilder {
@@ -53,6 +55,7 @@ open class BlockDisplayBuilder() {
     fun interpolationDuration(interpolationDuration: Int): BlockDisplayBuilder = apply { this.interpolationDuration = interpolationDuration }
     fun displayWidth(displayWidth: Float): BlockDisplayBuilder = apply { this.displayWidth = displayWidth }
     fun displayHeight(displayHeight: Float): BlockDisplayBuilder = apply { this.displayHeight = displayHeight }
+    fun persistent(persistent: Boolean): BlockDisplayBuilder = apply { this.persistent = persistent }
 
     open fun build(location: Location): BlockDisplay {
         val finalLocation = location.clone()
@@ -92,6 +95,9 @@ open class BlockDisplayBuilder() {
         }
         if (displayHeight != null) {
             display.displayHeight = displayHeight!!
+        }
+        if (persistent != null) {
+            display.isPersistent = persistent!!
         }
     }
 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/display/ItemDisplayBuilder.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/display/ItemDisplayBuilder.kt
@@ -16,17 +16,18 @@ import org.joml.Matrix4f
 @Suppress("unused")
 open class ItemDisplayBuilder() {
 
-    var itemStack: ItemStack? = null
-    var itemDisplayTransform : ItemDisplay.ItemDisplayTransform? = null
-    var transformation: Matrix4f? = null
-    var brightness: Brightness? = null
-    var glowColor: Color? = null
-    var billboard: Billboard? = null
-    var viewRange: Float? = null
-    var interpolationDelay: Int? = null
-    var interpolationDuration: Int? = null
-    var displayWidth: Float? = null
-    var displayHeight: Float? = null
+    protected var itemStack: ItemStack? = null
+    protected var itemDisplayTransform : ItemDisplay.ItemDisplayTransform? = null
+    protected var transformation: Matrix4f? = null
+    protected var brightness: Brightness? = null
+    protected var glowColor: Color? = null
+    protected var billboard: Billboard? = null
+    protected var viewRange: Float? = null
+    protected var interpolationDelay: Int? = null
+    protected var interpolationDuration: Int? = null
+    protected var displayWidth: Float? = null
+    protected var displayHeight: Float? = null
+    protected var persistent: Boolean? = null
 
     constructor(other: ItemDisplayBuilder): this() {
         this.itemStack = other.itemStack
@@ -40,6 +41,7 @@ open class ItemDisplayBuilder() {
         this.interpolationDuration = other.interpolationDuration
         this.displayWidth = other.displayWidth
         this.displayHeight = other.displayHeight
+        this.persistent = other.persistent
     }
 
     fun material(material: Material) = apply { this.itemStack = ItemStack(material) }
@@ -57,6 +59,7 @@ open class ItemDisplayBuilder() {
     fun interpolationDuration(interpolationDuration: Int) = apply { this.interpolationDuration = interpolationDuration }
     fun displayWidth(displayWidth: Float): ItemDisplayBuilder = apply { this.displayWidth = displayWidth }
     fun displayHeight(displayHeight: Float): ItemDisplayBuilder = apply { this.displayHeight = displayHeight }
+    fun persistent(persistent: Boolean): ItemDisplayBuilder = apply { this.persistent = persistent }
 
     open fun build(location: Location): ItemDisplay {
         val finalLocation = location.clone()
@@ -102,6 +105,9 @@ open class ItemDisplayBuilder() {
         }
         if (displayHeight != null) {
             display.displayWidth = displayHeight!!
+        }
+        if (persistent != null) {
+            display.isPersistent = persistent!!
         }
     }
 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/display/TextDisplayBuilder.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/display/TextDisplayBuilder.kt
@@ -24,6 +24,7 @@ open class TextDisplayBuilder() {
     protected var backgroundColor: Color? = null
     protected var interpolationDelay: Int? = null
     protected var interpolationDuration: Int? = null
+    protected var persistent: Boolean? = null
 
     constructor(other: TextDisplayBuilder) : this() {
         this.text = other.text
@@ -36,6 +37,7 @@ open class TextDisplayBuilder() {
         this.backgroundColor = other.backgroundColor
         this.interpolationDelay = other.interpolationDelay
         this.interpolationDuration = other.interpolationDuration
+        this.persistent = other.persistent
     }
 
     fun text(text: String): TextDisplayBuilder = apply { this.text = Component.text(text) }
@@ -51,6 +53,7 @@ open class TextDisplayBuilder() {
     fun backgroundColor(backgroundColor: Color?): TextDisplayBuilder = apply { this.backgroundColor = backgroundColor }
     fun interpolationDelay(interpolationDelay: Int): TextDisplayBuilder = apply { this.interpolationDelay = interpolationDelay }
     fun interpolationDuration(interpolationDuration: Int): TextDisplayBuilder = apply { this.interpolationDuration = interpolationDuration }
+    fun persistent(persistent: Boolean): TextDisplayBuilder = apply { this.persistent = persistent }
 
     open fun build(location: Location): TextDisplay {
         val finalLocation = location.clone()
@@ -91,6 +94,9 @@ open class TextDisplayBuilder() {
         }
         if (interpolationDuration != null) {
             display.interpolationDuration = interpolationDuration!!
+        }
+        if (persistent != null) {
+            display.isPersistent = persistent!!
         }
     }
 }

--- a/rebar/src/main/resources/config.yml
+++ b/rebar/src/main/resources/config.yml
@@ -27,6 +27,9 @@ entity-data-autosave-interval-seconds: 60
 # The lowest tick interval at which Rebar inventory ticker items may tick
 inventory-ticker-base-rate: 10
 
+# The number of ticks between ghost blocks with multiple states changing to the next state
+ghost-block-tick-interval: 20
+
 waila:
   # The interval (in Minecraft ticks), between WAILA checks
   # Set to 0 to disable WAILA globally

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/TestRebarSimpleMultiblock.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/TestRebarSimpleMultiblock.java
@@ -30,8 +30,8 @@ public class TestRebarSimpleMultiblock extends RebarBlock implements RebarSimple
     @Override
     public @NotNull Map<Vector3i, MultiblockComponent> getComponents() {
         return Map.of(
-                new Vector3i(1, 1, 4), new RebarMultiblockComponent(Blocks.SIMPLE_BLOCK_KEY),
-                new Vector3i(2, -1, 0), new RebarMultiblockComponent(Blocks.SIMPLE_BLOCK_KEY)
+                new Vector3i(1, 1, 4), MultiblockComponent.of(Blocks.SIMPLE_BLOCK_KEY),
+                new Vector3i(2, -1, 0), MultiblockComponent.of(Blocks.SIMPLE_BLOCK_KEY)
         );
     }
 }


### PR DESCRIPTION
Ghost blocks and multiblock components have become quite a mess with all the changes that have been made. This PR cleans it up by unifying the multiblock components under a single class (there was never really any good reason for it to be an interface) and adding an abstraction layer (`RebarGhostBlockHolder`) which separates the ghost block logic from the multiblock logic. The abstraction layer will also allow implementors of `RebarMultiblock` to spawn their own ghost blocks easily, which was previously very annoying to do. This also unifies handling of mixed multiblock components (rebar/vanilla) which has removed a lot of unnecessary logic.