### PR TITLE
feat(RebarTranslator): apply white color to item names if not set

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/RebarTranslator.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/RebarTranslator.kt
@@ -20,6 +20,7 @@ import io.papermc.paper.datacomponent.item.ItemLore
 import io.papermc.paper.datacomponent.item.ResolvableProfile
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.*
+import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.translation.GlobalTranslator
 import net.kyori.adventure.translation.Translator
@@ -218,12 +219,14 @@ class RebarTranslator private constructor(private val addon: RebarAddon) : Trans
                 }
 
                 val translated = GlobalTranslator.render(it.withArguments(concatenatedArguments), locale)
-                if (translated is TranslatableComponent && translated.fallback() != null) {
+                val result = if (translated is TranslatableComponent && translated.fallback() != null) {
                     Component.text(translated.fallback()!!)
                 } else {
                     translated
                 }
 
+                // apply white color if not set
+                if (result.style().color() == null) result.color(NamedTextColor.WHITE) else result
             }
             editData(DataComponentTypes.LORE) { lore ->
                 val newLore = lore.lines().flatMap { line ->


### PR DESCRIPTION
Fixes #741

After fix, removed `<white>` from item name: 
<img width="424" height="96" alt="Image_2026-05-10_13-06-01_5v0quhna mkz" src="https://github.com/user-attachments/assets/07584b7b-bed8-4bac-8cf3-7fbc05f7343d" />

Also I changed the `Liselette Collector` to `<lang:pylon.item.liselette_collector.name/>`:
<img width="316" height="389" alt="Image_2026-05-10_13-09-57_ib5n1rro hzj" src="https://github.com/user-attachments/assets/caf95cc1-3236-4357-8e28-19d0811969bb" />
