### PR TITLE
Test Fixes and Improvements

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/BlockListener.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/BlockListener.kt
@@ -384,7 +384,7 @@ internal object BlockListener : MultiListener {
         } else {
             Rebar.logger.severe("Error when handling block(${block.key}, ${block.block.location}) ticking: ${e.localizedMessage}")
         }
-        e.printStackTrace()
+        if (RebarConfig.FULL_ERROR_STACK_TRACES) e.printStackTrace()
         blockErrMap[block] = blockErrMap[block]?.plus(1) ?: 1
         if (blockErrMap[block]!! > RebarConfig.ALLOWED_BLOCK_ERRORS) {
             BlockStorage.makePhantom(block)

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/config/RebarConfig.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/config/RebarConfig.kt
@@ -24,6 +24,12 @@ object RebarConfig {
     @JvmField
     val ALLOWED_ENTITY_ERRORS = config.getOrThrow("allowed-entity-errors", ConfigAdapter.INTEGER)
 
+    /**
+     * Mutable so that they can be disabled/enabled live for things like tests, etc.
+     */
+    @JvmField
+    var FULL_ERROR_STACK_TRACES = config.getOrThrow("full-error-stack-traces", ConfigAdapter.BOOLEAN)
+
     @JvmField
     val FLUID_TICK_INTERVAL = config.getOrThrow("fluid-tick-interval", ConfigAdapter.INTEGER)
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/EntityListener.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/EntityListener.kt
@@ -14,7 +14,7 @@ internal object EntityListener : MultiListener {
     @JvmSynthetic
     internal fun logEventHandleErr(event: Event, e: Exception, entity: RebarEntity<*>) {
         Rebar.logger.severe("Error when handling entity(${entity.key}, ${entity.uuid}, ${entity.entity.location}) event handler ${event.javaClass.simpleName}: ${e.localizedMessage}")
-        e.printStackTrace()
+        if (RebarConfig.FULL_ERROR_STACK_TRACES) e.printStackTrace()
         entityErrMap[entity.uuid] = entityErrMap[entity.uuid]?.plus(1) ?: 1
         if (entityErrMap[entity.uuid]!! > RebarConfig.ALLOWED_ENTITY_ERRORS) {
             entity.entity.remove()
@@ -22,9 +22,9 @@ internal object EntityListener : MultiListener {
     }
 
     @JvmSynthetic
-    internal fun logEventHandleErrTicking(e: Exception, entity: RebarEntity<*>) {
+    internal fun logTickingErr(e: Exception, entity: RebarEntity<*>) {
         Rebar.logger.severe("Error when handling ticking entity(${entity.key}, ${entity.uuid}, ${entity.entity.location}): ${e.localizedMessage}")
-        e.printStackTrace()
+        if (RebarConfig.FULL_ERROR_STACK_TRACES) e.printStackTrace()
         entityErrMap[entity.uuid] = entityErrMap[entity.uuid]?.plus(1) ?: 1
         if (entityErrMap[entity.uuid]!! > RebarConfig.ALLOWED_ENTITY_ERRORS) {
             entity.entity.remove()

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/base/RebarTickingEntity.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/base/RebarTickingEntity.kt
@@ -132,7 +132,7 @@ interface RebarTickingEntity {
                         tickingEntity.tick()
                     } catch (e: Exception) {
                         withContext(Rebar.mainThreadDispatcher) {
-                            EntityListener.logEventHandleErrTicking(e, tickingEntity as RebarEntity<*>)
+                            EntityListener.logTickingErr(e, tickingEntity as RebarEntity<*>)
                         }
                     }
                 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/gametest/GameTest.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/gametest/GameTest.kt
@@ -127,6 +127,7 @@ class GameTest(
                 } catch (e: Throwable) {
                     result = GameTestFailException(gameTest, "An exception occurred", e)
                 }
+                gameTest.config.cleanup.accept(gameTest)
                 for (entity in gameTest.world.getNearbyEntities(gameTest.boundingBox)) {
                     if (entity !is Player) {
                         entity.remove()

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/gametest/GameTestConfig.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/gametest/GameTestConfig.kt
@@ -19,6 +19,7 @@ class GameTestConfig(
     private val key: NamespacedKey,
     val size: Int,
     val setUp: Consumer<GameTest>,
+    val cleanup: Consumer<GameTest>,
     val delayTicks: Long,
     val timeoutTicks: Long,
     val positionOverride: BlockPosition?
@@ -31,6 +32,7 @@ class GameTestConfig(
     class Builder(val key: NamespacedKey) {
         private var size by Delegates.notNull<Int>()
         private var setUp: Consumer<GameTest> = Consumer {}
+        private var cleanup: Consumer<GameTest> = Consumer {}
         private var delayTicks = 0L
         private var timeoutTicks = 5L * 60 * 20
         private var positionOverride: BlockPosition? = null
@@ -48,6 +50,13 @@ class GameTestConfig(
         fun setUp(setUp: Consumer<GameTest>): Builder = apply { this.setUp = setUp }
 
         /**
+         * Runs after test ends
+         */
+        fun cleanup(cleanup: Consumer<GameTest>): Builder = apply {
+            this.cleanup = cleanup
+        }
+
+        /**
          * Delay in ticks before the test starts. Defaults to 0.
          */
         fun delayTicks(delayTicks: Long): Builder = apply { this.delayTicks = delayTicks }
@@ -62,7 +71,7 @@ class GameTestConfig(
          */
         fun positionOverride(position: BlockPosition): Builder = apply { this.positionOverride = position }
 
-        fun build() = GameTestConfig(key, size, setUp, delayTicks, timeoutTicks, positionOverride)
+        fun build() = GameTestConfig(key, size, setUp, cleanup, delayTicks, timeoutTicks, positionOverride)
     }
 
     /**

--- a/rebar/src/main/resources/config.yml
+++ b/rebar/src/main/resources/config.yml
@@ -11,6 +11,9 @@ allowed-block-errors: 5
 # The number of errors a entity can throw before it is disabled
 allowed-entity-errors: 5
 
+# When a block or entity errors, should the full error stack trace be printed in the console or just the error message & context?
+full-error-stack-traces: true
+
 # The interval (in Minecraft ticks) between fluid network ticks
 fluid-tick-interval: 5
 

--- a/test/src/main/java/io/github/pylonmc/rebar/test/RebarTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/RebarTest.java
@@ -1,12 +1,13 @@
 package io.github.pylonmc.rebar.test;
 
 import io.github.pylonmc.rebar.addon.RebarAddon;
+import io.github.pylonmc.rebar.config.RebarConfig;
 import io.github.pylonmc.rebar.test.base.Test;
 import io.github.pylonmc.rebar.test.base.TestResult;
-import io.github.pylonmc.rebar.test.block.Blocks;
-import io.github.pylonmc.rebar.test.entity.Entities;
-import io.github.pylonmc.rebar.test.fluid.Fluids;
-import io.github.pylonmc.rebar.test.item.Items;
+import io.github.pylonmc.rebar.test.block.TestBlocks;
+import io.github.pylonmc.rebar.test.entity.TestEntities;
+import io.github.pylonmc.rebar.test.fluid.TestFluids;
+import io.github.pylonmc.rebar.test.item.TestItems;
 import io.github.pylonmc.rebar.test.test.block.*;
 import io.github.pylonmc.rebar.test.test.entity.EntityEventErrorTest;
 import io.github.pylonmc.rebar.test.test.entity.EntityStorageChunkReloadTest;
@@ -112,10 +113,10 @@ public class RebarTest extends JavaPlugin implements RebarAddon {
 
             try {
                 // TODO get rid of these and convert registration to static blocks
-                Blocks.register();
-                Items.register();
-                Entities.register();
-                Fluids.register();
+                TestBlocks.register();
+                TestItems.register();
+                TestEntities.register();
+                TestFluids.register();
             } catch (Exception e) {
                 instance().getLogger().severe("Failed to set up tests");
                 e.printStackTrace();
@@ -130,7 +131,7 @@ public class RebarTest extends JavaPlugin implements RebarAddon {
         List<Test> tests = TestUtil.runSync(RebarTest::initTests).join();
 
         List<TestResult> results = tests.stream()
-                .map(Test::run)
+                .map(Test::start)
                 .toList();
 
         List<NamespacedKey> succeeded = results.stream()

--- a/test/src/main/java/io/github/pylonmc/rebar/test/base/Test.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/base/Test.java
@@ -11,6 +11,11 @@ import java.util.logging.Level;
 
 
 public interface Test {
+    default TestResult start() {
+        RebarTest.instance().getLogger().log(Level.INFO, "Test %s started".formatted(getKey()));
+        return run();
+    }
+
     TestResult run();
 
     default NamespacedKey getKey() {

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/TestBlocks.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/TestBlocks.java
@@ -10,9 +10,9 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 
 
-public final class Blocks {
+public final class TestBlocks {
 
-    private Blocks() {}
+    private TestBlocks() {}
 
     public static final NamespacedKey SIMPLE_BLOCK_KEY = RebarTest.key("simple_block");
 

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/TestRebarSimpleMultiblock.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/TestRebarSimpleMultiblock.java
@@ -30,8 +30,8 @@ public class TestRebarSimpleMultiblock extends RebarBlock implements RebarSimple
     @Override
     public @NotNull Map<Vector3i, MultiblockComponent> getComponents() {
         return Map.of(
-                new Vector3i(1, 1, 4), MultiblockComponent.of(Blocks.SIMPLE_BLOCK_KEY),
-                new Vector3i(2, -1, 0), MultiblockComponent.of(Blocks.SIMPLE_BLOCK_KEY)
+                new Vector3i(1, 1, 4), MultiblockComponent.of(TestBlocks.SIMPLE_BLOCK_KEY),
+                new Vector3i(2, -1, 0), MultiblockComponent.of(TestBlocks.SIMPLE_BLOCK_KEY)
         );
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/TickingErrorBlock.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/TickingErrorBlock.java
@@ -3,6 +3,7 @@ package io.github.pylonmc.rebar.test.block;
 import io.github.pylonmc.rebar.block.RebarBlock;
 import io.github.pylonmc.rebar.block.base.RebarTickingBlock;
 import io.github.pylonmc.rebar.block.context.BlockCreateContext;
+import io.github.pylonmc.rebar.config.RebarConfig;
 import io.github.pylonmc.rebar.test.RebarTest;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/fluid/FluidConsumer.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/fluid/FluidConsumer.java
@@ -11,7 +11,7 @@ import io.github.pylonmc.rebar.fluid.FluidPointType;
 import io.github.pylonmc.rebar.fluid.RebarFluid;
 import io.github.pylonmc.rebar.fluid.VirtualFluidPoint;
 import io.github.pylonmc.rebar.test.RebarTest;
-import io.github.pylonmc.rebar.test.fluid.Fluids;
+import io.github.pylonmc.rebar.test.fluid.TestFluids;
 import lombok.Getter;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
@@ -63,8 +63,8 @@ public class FluidConsumer extends RebarBlock implements RebarFluidBufferBlock, 
 
     private RebarFluid getFluidType() {
         return Map.of(
-                LAVA_CONSUMER_KEY, Fluids.LAVA,
-                WATER_CONSUMER_KEY, Fluids.WATER
+                LAVA_CONSUMER_KEY, TestFluids.LAVA,
+                WATER_CONSUMER_KEY, TestFluids.WATER
         ).get(getKey());
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/block/fluid/FluidProducer.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/block/fluid/FluidProducer.java
@@ -12,7 +12,7 @@ import io.github.pylonmc.rebar.fluid.FluidPointType;
 import io.github.pylonmc.rebar.fluid.RebarFluid;
 import io.github.pylonmc.rebar.fluid.VirtualFluidPoint;
 import io.github.pylonmc.rebar.test.RebarTest;
-import io.github.pylonmc.rebar.test.fluid.Fluids;
+import io.github.pylonmc.rebar.test.fluid.TestFluids;
 import kotlin.Pair;
 import lombok.Getter;
 import org.bukkit.NamespacedKey;
@@ -72,8 +72,8 @@ public class FluidProducer extends RebarBlock implements RebarFluidBlock, RebarU
 
     private RebarFluid getFluidType() {
         return Map.of(
-                LAVA_PRODUCER_KEY, Fluids.LAVA,
-                WATER_PRODUCER_KEY, Fluids.WATER
+                LAVA_PRODUCER_KEY, TestFluids.LAVA,
+                WATER_PRODUCER_KEY, TestFluids.WATER
         ).get(getKey());
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/entity/EntityEventError.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/entity/EntityEventError.java
@@ -1,6 +1,7 @@
 package io.github.pylonmc.rebar.test.entity;
 
 import io.github.pylonmc.rebar.entity.RebarEntity;
+import io.github.pylonmc.rebar.entity.base.RebarDamageableEntity;
 import io.github.pylonmc.rebar.entity.base.RebarInteractEntity;
 import io.github.pylonmc.rebar.test.RebarTest;
 import org.bukkit.Location;
@@ -8,11 +9,12 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Skeleton;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.jetbrains.annotations.NotNull;
 
 
-public class EntityEventError extends RebarEntity<LivingEntity> implements RebarInteractEntity {
+public class EntityEventError extends RebarEntity<LivingEntity> implements RebarDamageableEntity {
 
     public static final NamespacedKey KEY = RebarTest.key("entity_event_error");
 
@@ -26,7 +28,7 @@ public class EntityEventError extends RebarEntity<LivingEntity> implements Rebar
     }
 
     @Override
-    public void onInteract(@NotNull PlayerInteractEntityEvent event, @NotNull EventPriority priority) {
+    public void onDamage(@NotNull EntityDamageEvent event, @NotNull EventPriority priority) {
         throw new RuntimeException("This exception is thrown as part of a test");
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/entity/TestEntities.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/entity/TestEntities.java
@@ -4,9 +4,9 @@ import io.github.pylonmc.rebar.entity.RebarEntity;
 import org.bukkit.entity.LivingEntity;
 
 
-public final class Entities {
+public final class TestEntities {
 
-    private Entities() {}
+    private TestEntities() {}
 
     public static void register() {
         RebarEntity.register(SimpleEntity.KEY, LivingEntity.class, SimpleEntity.class);

--- a/test/src/main/java/io/github/pylonmc/rebar/test/fluid/TestFluids.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/fluid/TestFluids.java
@@ -5,7 +5,7 @@ import io.github.pylonmc.rebar.test.RebarTest;
 import org.bukkit.Material;
 
 
-public class Fluids {
+public class TestFluids {
 
     public static final RebarFluid WATER = new RebarFluid(RebarTest.key("water"),  Material.CYAN_CONCRETE);
     public static final RebarFluid LAVA = new RebarFluid(RebarTest.key("lava"), Material.ORANGE_CONCRETE)

--- a/test/src/main/java/io/github/pylonmc/rebar/test/item/TestItems.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/item/TestItems.java
@@ -3,15 +3,17 @@ package io.github.pylonmc.rebar.test.item;
 import io.github.pylonmc.rebar.item.RebarItem;
 import io.github.pylonmc.rebar.item.builder.ItemStackBuilder;
 import io.github.pylonmc.rebar.test.RebarTest;
+import io.github.pylonmc.rebar.test.block.TestBlocks;
+import io.github.pylonmc.rebar.test.block.TestRebarSimpleMultiblock;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 
-public final class Items {
+public final class TestItems {
 
-    private Items() {}
+    private TestItems() {}
 
     public static final NamespacedKey STICKY_STICK_KEY = RebarTest.key("sticky_stick");
     public static final ItemStack STICKY_STICK_STACK = ItemStackBuilder.rebar(Material.STICK, STICKY_STICK_KEY)
@@ -21,5 +23,7 @@ public final class Items {
     public static void register() {
         RebarItem.register(RebarItem.class, STICKY_STICK_STACK);
         RebarItem.register(OminousBlazePower.class, OminousBlazePower.STACK);
+        RebarItem.register(RebarItem.class, ItemStackBuilder.rebar(Material.AMETHYST_BLOCK, TestBlocks.SIMPLE_BLOCK_KEY).build());
+        RebarItem.register(RebarItem.class, ItemStackBuilder.rebar(Material.AMETHYST_BLOCK, TestRebarSimpleMultiblock.KEY).build());
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/block/BlockEventErrorTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/block/BlockEventErrorTest.java
@@ -19,12 +19,17 @@ public class BlockEventErrorTest extends GameTest {
         super(new GameTestConfig.Builder(new NamespacedKey(RebarTest.instance(), "block_event_error_test"))
                 .size(1)
                 .setUp(test -> {
+                    RebarConfig.FULL_ERROR_STACK_TRACES = false;
                     Block block = BlockStorage.placeBlock(test.location(), BlockEventError.KEY).getBlock();
                     Entity theRinger = test.location().getWorld().spawn(test.location().clone().add(1, 0, 0), Skeleton.class);
                     for(int i = 0; i < RebarConfig.ALLOWED_BLOCK_ERRORS + 1; i++){
                         new BellRingEvent(block, BlockFace.EAST, theRinger).callEvent();
                     }
                     test.succeedWhen(() -> BlockStorage.get(block) instanceof PhantomBlock);
+                })
+                .cleanup(test -> {
+                    BlockStorage.breakBlock(test.location());
+                    RebarConfig.FULL_ERROR_STACK_TRACES = true;
                 })
                 .build()
         );

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/block/BlockStorageAddTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/block/BlockStorageAddTest.java
@@ -5,7 +5,7 @@ import io.github.pylonmc.rebar.block.RebarBlock;
 import io.github.pylonmc.rebar.gametest.GameTestConfig;
 import io.github.pylonmc.rebar.test.RebarTest;
 import io.github.pylonmc.rebar.test.base.GameTest;
-import io.github.pylonmc.rebar.test.block.Blocks;
+import io.github.pylonmc.rebar.test.block.TestBlocks;
 import org.bukkit.NamespacedKey;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,7 +16,7 @@ public class BlockStorageAddTest extends GameTest {
         super(new GameTestConfig.Builder(new NamespacedKey(RebarTest.instance(), "block_storage_add_test"))
                 .size(1)
                 .setUp((test) -> {
-                    BlockStorage.placeBlock(test.location(), Blocks.SIMPLE_BLOCK_KEY);
+                    BlockStorage.placeBlock(test.location(), TestBlocks.SIMPLE_BLOCK_KEY);
 
                     RebarBlock rebarBlock = BlockStorage.get(test.location());
 
@@ -26,6 +26,8 @@ public class BlockStorageAddTest extends GameTest {
 
                     assertThat(BlockStorage.getAs(RebarBlock.class, test.location()))
                             .isNotNull();
+
+                    BlockStorage.breakBlock(test.location());
                 })
                 .build());
     }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/block/BlockStorageFilledChunkTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/block/BlockStorageFilledChunkTest.java
@@ -4,7 +4,7 @@ import io.github.pylonmc.rebar.block.BlockStorage;
 import io.github.pylonmc.rebar.block.RebarBlock;
 import io.github.pylonmc.rebar.block.RebarBlockSchema;
 import io.github.pylonmc.rebar.test.base.AsyncTest;
-import io.github.pylonmc.rebar.test.block.Blocks;
+import io.github.pylonmc.rebar.test.block.TestBlocks;
 import io.github.pylonmc.rebar.test.util.TestUtil;
 import org.bukkit.Chunk;
 import org.bukkit.block.Block;
@@ -18,7 +18,7 @@ public class BlockStorageFilledChunkTest extends AsyncTest {
 
     @Override
     public void test() {
-        Chunk chunk = TestUtil.getRandomChunk(true).join();
+        Chunk chunk = TestUtil.getRandomChunk(false).join();
 
         List<Block> blocks = new ArrayList<>();
         for (int x = 0; x < 16; x++) {
@@ -29,10 +29,9 @@ public class BlockStorageFilledChunkTest extends AsyncTest {
             }
         }
 
-        TestUtil.loadChunk(chunk).join();
         TestUtil.runSync(() -> {
             for (Block block : blocks) {
-                BlockStorage.placeBlock(block, Blocks.SIMPLE_BLOCK_KEY);
+                BlockStorage.placeBlock(block, TestBlocks.SIMPLE_BLOCK_KEY);
             }
         }).join();
         TestUtil.unloadChunk(chunk).join();
@@ -46,7 +45,7 @@ public class BlockStorageFilledChunkTest extends AsyncTest {
 
             assertThat(rebarBlock.getSchema())
                     .extracting(RebarBlockSchema::getKey)
-                    .isEqualTo(Blocks.SIMPLE_BLOCK_KEY);
+                    .isEqualTo(TestBlocks.SIMPLE_BLOCK_KEY);
         }
         TestUtil.unloadChunk(chunk).join();
     }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/block/BlockStorageRemoveTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/block/BlockStorageRemoveTest.java
@@ -4,7 +4,7 @@ import io.github.pylonmc.rebar.block.BlockStorage;
 import io.github.pylonmc.rebar.gametest.GameTestConfig;
 import io.github.pylonmc.rebar.test.RebarTest;
 import io.github.pylonmc.rebar.test.base.GameTest;
-import io.github.pylonmc.rebar.test.block.Blocks;
+import io.github.pylonmc.rebar.test.block.TestBlocks;
 import org.bukkit.NamespacedKey;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,7 +15,7 @@ public class BlockStorageRemoveTest extends GameTest {
         super(new GameTestConfig.Builder(new NamespacedKey(RebarTest.instance(), "block_storage_remove_test"))
                 .size(1)
                 .setUp((test) -> {
-                    BlockStorage.placeBlock(test.location(), Blocks.SIMPLE_BLOCK_KEY);
+                    BlockStorage.placeBlock(test.location(), TestBlocks.SIMPLE_BLOCK_KEY);
                     assertThat(BlockStorage.get(test.location()))
                             .isNotNull();
 

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/block/SimpleMultiblockRotatedTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/block/SimpleMultiblockRotatedTest.java
@@ -2,7 +2,7 @@ package io.github.pylonmc.rebar.test.test.block;
 
 import io.github.pylonmc.rebar.block.BlockStorage;
 import io.github.pylonmc.rebar.test.base.AsyncTest;
-import io.github.pylonmc.rebar.test.block.Blocks;
+import io.github.pylonmc.rebar.test.block.TestBlocks;
 import io.github.pylonmc.rebar.test.block.TestRebarSimpleMultiblock;
 import io.github.pylonmc.rebar.test.util.TestUtil;
 import org.bukkit.Chunk;
@@ -16,7 +16,6 @@ public class SimpleMultiblockRotatedTest extends AsyncTest {
     @Override
     protected void test() {
         Chunk chunk = TestUtil.getRandomChunk(false).join();
-        chunk.setForceLoaded(true);
 
         Location multiblockLocation = chunk.getBlock(5, 100, 5).getLocation();
 
@@ -26,8 +25,8 @@ public class SimpleMultiblockRotatedTest extends AsyncTest {
         Location component1Location0 = multiblockLocation.clone().add(1, 1, 4);
         Location component2Location0 = multiblockLocation.clone().add(2, -1, 0);
         TestUtil.runSync(() -> {
-            BlockStorage.placeBlock(component1Location0, Blocks.SIMPLE_BLOCK_KEY);
-            BlockStorage.placeBlock(component2Location0, Blocks.SIMPLE_BLOCK_KEY);
+            BlockStorage.placeBlock(component1Location0, TestBlocks.SIMPLE_BLOCK_KEY);
+            BlockStorage.placeBlock(component2Location0, TestBlocks.SIMPLE_BLOCK_KEY);
         }).join();
         TestUtil.sleepTicks(2).join();
         assertMultiblockFormed(multiblockLocation, true);
@@ -43,8 +42,8 @@ public class SimpleMultiblockRotatedTest extends AsyncTest {
         Location component1Location1 = multiblockLocation.clone().add(-4, 1, 1);
         Location component2Location1 = multiblockLocation.clone().add(0, -1, 2);
         TestUtil.runSync(() -> {
-            BlockStorage.placeBlock(component1Location1, Blocks.SIMPLE_BLOCK_KEY);
-            BlockStorage.placeBlock(component2Location1, Blocks.SIMPLE_BLOCK_KEY);
+            BlockStorage.placeBlock(component1Location1, TestBlocks.SIMPLE_BLOCK_KEY);
+            BlockStorage.placeBlock(component2Location1, TestBlocks.SIMPLE_BLOCK_KEY);
         }).join();
         TestUtil.sleepTicks(2).join();
         assertMultiblockFormed(multiblockLocation, true);
@@ -60,8 +59,8 @@ public class SimpleMultiblockRotatedTest extends AsyncTest {
         Location component1Location2 = multiblockLocation.clone().add(-1, 1, -4);
         Location component2Location2 = multiblockLocation.clone().add(-2, -1, 0);
         TestUtil.runSync(() -> {
-            BlockStorage.placeBlock(component1Location2, Blocks.SIMPLE_BLOCK_KEY);
-            BlockStorage.placeBlock(component2Location2, Blocks.SIMPLE_BLOCK_KEY);
+            BlockStorage.placeBlock(component1Location2, TestBlocks.SIMPLE_BLOCK_KEY);
+            BlockStorage.placeBlock(component2Location2, TestBlocks.SIMPLE_BLOCK_KEY);
         }).join();
         TestUtil.sleepTicks(2).join();
         assertMultiblockFormed(multiblockLocation, true);
@@ -77,8 +76,8 @@ public class SimpleMultiblockRotatedTest extends AsyncTest {
         Location component1Location3 = multiblockLocation.clone().add(4, 1, -1);
         Location component2Location3 = multiblockLocation.clone().add(0, -1, -2);
         TestUtil.runSync(() -> {
-            BlockStorage.placeBlock(component1Location3, Blocks.SIMPLE_BLOCK_KEY);
-            BlockStorage.placeBlock(component2Location3, Blocks.SIMPLE_BLOCK_KEY);
+            BlockStorage.placeBlock(component1Location3, TestBlocks.SIMPLE_BLOCK_KEY);
+            BlockStorage.placeBlock(component2Location3, TestBlocks.SIMPLE_BLOCK_KEY);
         }).join();
         TestUtil.sleepTicks(2).join();
         assertMultiblockFormed(multiblockLocation, true);
@@ -90,6 +89,6 @@ public class SimpleMultiblockRotatedTest extends AsyncTest {
         TestUtil.sleepTicks(2).join();
         assertMultiblockFormed(multiblockLocation, false);
 
-        chunk.setForceLoaded(false);
+        TestUtil.unloadChunk(chunk).join();
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/block/SimpleMultiblockTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/block/SimpleMultiblockTest.java
@@ -2,7 +2,7 @@ package io.github.pylonmc.rebar.test.test.block;
 
 import io.github.pylonmc.rebar.block.BlockStorage;
 import io.github.pylonmc.rebar.test.base.AsyncTest;
-import io.github.pylonmc.rebar.test.block.Blocks;
+import io.github.pylonmc.rebar.test.block.TestBlocks;
 import io.github.pylonmc.rebar.test.block.TestRebarSimpleMultiblock;
 import io.github.pylonmc.rebar.test.util.TestUtil;
 import org.bukkit.Chunk;
@@ -23,7 +23,6 @@ public class SimpleMultiblockTest extends AsyncTest {
     @Override
     protected void test() {
         Chunk chunk = TestUtil.getRandomChunk(false).join();
-        chunk.setForceLoaded(true);
 
         Location multiblockLocation = chunk.getBlock(5, 100, 5).getLocation();
         Location component1Location = multiblockLocation.clone().add(1, 1, 4);
@@ -33,11 +32,11 @@ public class SimpleMultiblockTest extends AsyncTest {
         TestUtil.sleepTicks(2).join();
         assertMultiblockFormed(multiblockLocation, false);
 
-        TestUtil.runSync(() -> BlockStorage.placeBlock(component1Location, Blocks.SIMPLE_BLOCK_KEY)).join();
+        TestUtil.runSync(() -> BlockStorage.placeBlock(component1Location, TestBlocks.SIMPLE_BLOCK_KEY)).join();
         TestUtil.sleepTicks(2).join();
         assertMultiblockFormed(multiblockLocation, false);
 
-        TestUtil.runSync(() -> BlockStorage.placeBlock(component2Location, Blocks.SIMPLE_BLOCK_KEY)).join();
+        TestUtil.runSync(() -> BlockStorage.placeBlock(component2Location, TestBlocks.SIMPLE_BLOCK_KEY)).join();
         TestUtil.sleepTicks(2).join();
         assertMultiblockFormed(multiblockLocation, true);
 
@@ -45,12 +44,10 @@ public class SimpleMultiblockTest extends AsyncTest {
         TestUtil.sleepTicks(2).join();
         assertMultiblockFormed(multiblockLocation, false);
 
-        chunk.setForceLoaded(false);
         TestUtil.unloadChunk(chunk).join();
         TestUtil.loadChunk(chunk).join();
-        chunk.setForceLoaded(true);
 
-        TestUtil.runSync(() -> BlockStorage.placeBlock(component2Location, Blocks.SIMPLE_BLOCK_KEY)).join();
+        TestUtil.runSync(() -> BlockStorage.placeBlock(component2Location, TestBlocks.SIMPLE_BLOCK_KEY)).join();
         TestUtil.sleepTicks(2).join();
         assertMultiblockFormed(multiblockLocation, true);
 
@@ -61,6 +58,6 @@ public class SimpleMultiblockTest extends AsyncTest {
         TestUtil.sleepTicks(2).join();
         assertMultiblockFormed(multiblockLocation, true);
 
-        chunk.setForceLoaded(false);
+        TestUtil.unloadChunk(chunk).join();
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/block/TickingBlockErrorTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/block/TickingBlockErrorTest.java
@@ -2,6 +2,7 @@ package io.github.pylonmc.rebar.test.test.block;
 
 import io.github.pylonmc.rebar.block.BlockStorage;
 import io.github.pylonmc.rebar.block.base.RebarTickingBlock;
+import io.github.pylonmc.rebar.config.RebarConfig;
 import io.github.pylonmc.rebar.gametest.GameTestConfig;
 import io.github.pylonmc.rebar.test.RebarTest;
 import io.github.pylonmc.rebar.test.base.GameTest;
@@ -14,9 +15,14 @@ public class TickingBlockErrorTest extends GameTest {
         super(new GameTestConfig.Builder(RebarTest.key("ticking_error_block"))
                 .size(1)
                 .setUp((test) -> {
+                    RebarConfig.FULL_ERROR_STACK_TRACES = false;
                     BlockStorage.placeBlock(test.location(), TickingErrorBlock.KEY);
 
                     test.succeedWhen(() -> !RebarTickingBlock.isTicking(BlockStorage.get(test.location().getBlock())));
+                })
+                .cleanup(test -> {
+                    BlockStorage.breakBlock(test.location());
+                    RebarConfig.FULL_ERROR_STACK_TRACES = true;
                 })
                 .build());
     }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/block/TickingBlockTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/block/TickingBlockTest.java
@@ -1,6 +1,7 @@
 package io.github.pylonmc.rebar.test.test.block;
 
 import io.github.pylonmc.rebar.block.BlockStorage;
+import io.github.pylonmc.rebar.config.RebarConfig;
 import io.github.pylonmc.rebar.gametest.GameTestConfig;
 import io.github.pylonmc.rebar.test.RebarTest;
 import io.github.pylonmc.rebar.test.base.GameTest;
@@ -17,6 +18,7 @@ public class TickingBlockTest extends GameTest {
 
                     test.succeedWhen(() -> BlockStorage.getAs(TickingBlock.class, test.location()).ticks >= 5);
                 })
+                .cleanup(test -> BlockStorage.breakBlock(test.location()))
                 .build());
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/entity/EntityEventErrorTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/entity/EntityEventErrorTest.java
@@ -7,7 +7,6 @@ import io.github.pylonmc.rebar.test.RebarTest;
 import io.github.pylonmc.rebar.test.base.GameTest;
 import io.github.pylonmc.rebar.test.entity.EntityEventError;
 import org.bukkit.NamespacedKey;
-import org.bukkit.event.entity.EntityDamageEvent;
 
 import java.util.UUID;
 
@@ -22,11 +21,11 @@ public class EntityEventErrorTest extends GameTest {
                     UUID entityUUID = entity.getUuid();
                     for(int i = 0; i < RebarConfig.ALLOWED_ENTITY_ERRORS + 1; i++){
                         // Yes, this is cursed, yes it works.
-                        new EntityDamageEvent(entity.getEntity(), EntityDamageEvent.DamageCause.ENTITY_ATTACK, 1).callEvent();
+                        entity.getEntity().damage(0);
                     }
-                    RebarConfig.FULL_ERROR_STACK_TRACES = true;
                     test.succeedWhen(() -> !EntityStorage.isRebarEntity(entityUUID));
                 })
+                .cleanup(test -> RebarConfig.FULL_ERROR_STACK_TRACES = true)
                 .build());
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/entity/EntityEventErrorTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/entity/EntityEventErrorTest.java
@@ -7,7 +7,7 @@ import io.github.pylonmc.rebar.test.RebarTest;
 import io.github.pylonmc.rebar.test.base.GameTest;
 import io.github.pylonmc.rebar.test.entity.EntityEventError;
 import org.bukkit.NamespacedKey;
-import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 
 import java.util.UUID;
 
@@ -16,13 +16,15 @@ public class EntityEventErrorTest extends GameTest {
         super(new GameTestConfig.Builder(new NamespacedKey(RebarTest.instance(), "entity_event_error_test"))
                 .size(1)
                 .setUp(test -> {
+                    RebarConfig.FULL_ERROR_STACK_TRACES = false;
                     EntityEventError entity = new EntityEventError(test.location());
                     EntityStorage.add(entity);
                     UUID entityUUID = entity.getUuid();
                     for(int i = 0; i < RebarConfig.ALLOWED_ENTITY_ERRORS + 1; i++){
                         // Yes, this is cursed, yes it works.
-                        new PlayerInteractEntityEvent(null, entity.getEntity()).callEvent();
+                        new EntityDamageEvent(entity.getEntity(), EntityDamageEvent.DamageCause.ENTITY_ATTACK, 1).callEvent();
                     }
+                    RebarConfig.FULL_ERROR_STACK_TRACES = true;
                     test.succeedWhen(() -> !EntityStorage.isRebarEntity(entityUUID));
                 })
                 .build());

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/entity/EntityStorageChunkReloadTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/entity/EntityStorageChunkReloadTest.java
@@ -48,5 +48,7 @@ public class EntityStorageChunkReloadTest extends AsyncTest {
                 .isEqualTo(69);
         assertThat(((LivingEntity) EntityStorage.get(uuid).getEntity()).hasAI())
                 .isFalse();
+
+        TestUtil.unloadChunk(chunk).join();
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/entity/EntityStorageUnregisteredEntityTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/entity/EntityStorageUnregisteredEntityTest.java
@@ -80,5 +80,6 @@ public class EntityStorageUnregisteredEntityTest extends AsyncTest {
         assertThat(EntityStorage.get(uuid))
                 .isNotNull()
                 .isInstanceOf(UnregisteredEntity.class);
+        TestUtil.unloadChunk(chunk).join();
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidConnectionTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidConnectionTest.java
@@ -17,7 +17,6 @@ public class FluidConnectionTest extends AsyncTest {
     @Override
     protected void test() {
         Chunk chunk = TestUtil.getRandomChunk(false).join();
-        chunk.setForceLoaded(true);
 
         Block consumerBlock = chunk.getBlock(6, 64, 5);
         FluidConsumer consumer = (FluidConsumer) TestUtil.runSync(
@@ -65,6 +64,6 @@ public class FluidConnectionTest extends AsyncTest {
             BlockStorage.breakBlock(producerBlock);
         }).join();
 
-        chunk.setForceLoaded(false);
+        TestUtil.unloadChunk(chunk).join();
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidCyclicConnectionsTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidCyclicConnectionsTest.java
@@ -18,7 +18,6 @@ public class FluidCyclicConnectionsTest extends AsyncTest {
     @Override
     protected void test() {
         Chunk chunk = TestUtil.getRandomChunk(false).join();
-        chunk.setForceLoaded(true);
 
         Block producerBlock = chunk.getBlock(2, 64, 5);
         FluidProducer producer = (FluidProducer) TestUtil.runSync(
@@ -67,6 +66,6 @@ public class FluidCyclicConnectionsTest extends AsyncTest {
                 .isNotEqualTo(producer.getPoint().getSegment())
                 .isNotEqualTo(connector.getPoint().getSegment());
 
-        chunk.setForceLoaded(false);
+        TestUtil.unloadChunk(chunk).join();
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidFlowRateTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidFlowRateTest.java
@@ -17,7 +17,6 @@ public class FluidFlowRateTest extends AsyncTest {
     @Override
     protected void test() {
         Chunk chunk = TestUtil.getRandomChunk(false).join();
-        chunk.setForceLoaded(true);
 
         Block waterProducerBlock = chunk.getBlock(2, 64, 5);
         FluidProducer waterProducer = (FluidProducer) TestUtil.runSync(
@@ -53,6 +52,6 @@ public class FluidFlowRateTest extends AsyncTest {
                 .isGreaterThan(lavaConsumer.getAmount() - 0.101)
                 .isLessThan(lavaConsumer.getAmount() + 0.101);
 
-        chunk.setForceLoaded(false);
+        TestUtil.unloadChunk(chunk).join();
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidPartialReloadTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidPartialReloadTest.java
@@ -18,11 +18,8 @@ public class FluidPartialReloadTest extends AsyncTest {
     @Override
     protected void test() {
         Chunk producerChunk = TestUtil.getRandomChunk(false).join();
-        producerChunk.setForceLoaded(true);
         Chunk connectorChunk = TestUtil.getRandomChunk(false).join();
-        connectorChunk.setForceLoaded(true);
         Chunk consumerChunk = TestUtil.getRandomChunk(false).join();
-        consumerChunk.setForceLoaded(true);
 
         Block consumerBlock = consumerChunk.getBlock(6, 64, 5);
         FluidConsumer consumer = (FluidConsumer) TestUtil.runSync(
@@ -50,21 +47,19 @@ public class FluidPartialReloadTest extends AsyncTest {
                 .isEqualTo(producer.getPoint().getSegment());
 
         // After unloading the connector, the producer and consumer should have different segments
-        connectorChunk.setForceLoaded(false);
         TestUtil.unloadChunk(connectorChunk).join();
         assertThat(consumer.getPoint().getSegment())
                 .isNotEqualTo(producer.getPoint().getSegment());
 
         // When the chunk is reloaded, all should have the same segment again
         TestUtil.loadChunk(connectorChunk).join();
-        connectorChunk.setForceLoaded(true);
         FluidConnector reloadedConnector = BlockStorage.getAs(FluidConnector.class, connectorBlock);
         assertThat(consumer.getPoint().getSegment())
                 .isEqualTo(reloadedConnector.getPoint().getSegment())
                 .isEqualTo(producer.getPoint().getSegment());
 
-        producerChunk.setForceLoaded(false);
-        connectorChunk.setForceLoaded(false);
-        consumerChunk.setForceLoaded(false);
+        TestUtil.unloadChunk(producerChunk).join();
+        TestUtil.unloadChunk(connectorChunk).join();
+        TestUtil.unloadChunk(consumerChunk).join();
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidPredicateTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidPredicateTest.java
@@ -18,7 +18,6 @@ public class FluidPredicateTest extends AsyncTest {
     @Override
     protected void test() {
         Chunk chunk = TestUtil.getRandomChunk(false).join();
-        chunk.setForceLoaded(true);
 
         Block waterProducerBlock = chunk.getBlock(2, 64, 5);
         FluidProducer waterProducer = (FluidProducer) TestUtil.runSync(
@@ -59,6 +58,6 @@ public class FluidPredicateTest extends AsyncTest {
         assertThat(lavaConsumer.getAmount())
                 .isNotEqualTo(0);
 
-        chunk.setForceLoaded(false);
+        TestUtil.unloadChunk(chunk).join();
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidTickerTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidTickerTest.java
@@ -18,7 +18,6 @@ public class FluidTickerTest extends AsyncTest {
     @Override
     protected void test() {
         Chunk chunk = TestUtil.getRandomChunk(false).join();
-        chunk.setForceLoaded(true);
 
         Block producerBlock = chunk.getBlock(2, 64, 5);
         FluidProducer producer = (FluidProducer) TestUtil.runSync(
@@ -56,6 +55,6 @@ public class FluidTickerTest extends AsyncTest {
                 .isGreaterThanOrEqualTo(99.5)
                 .isLessThanOrEqualTo(100.5);
 
-        chunk.setForceLoaded(false);
+        TestUtil.unloadChunk(chunk).join();
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidTickerTestWithMixedFluids.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidTickerTestWithMixedFluids.java
@@ -16,7 +16,6 @@ public class FluidTickerTestWithMixedFluids extends AsyncTest {
     @Override
     protected void test() {
         Chunk chunk = TestUtil.getRandomChunk(false).join();
-        chunk.setForceLoaded(true);
 
         Block producerBlock1 = chunk.getBlock(2, 64, 4);
         FluidProducer producer1 = (FluidProducer) TestUtil.runSync(
@@ -52,6 +51,6 @@ public class FluidTickerTestWithMixedFluids extends AsyncTest {
 
         TestUtil.waitUntil(() -> consumer1.getAmount() == 100 && consumer2.getAmount() == 100).join();
 
-        chunk.setForceLoaded(false);
+        TestUtil.unloadChunk(chunk).join();
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/item/RebarItemStackInterfaceTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/item/RebarItemStackInterfaceTest.java
@@ -1,5 +1,6 @@
 package io.github.pylonmc.rebar.test.test.item;
 
+import io.github.pylonmc.rebar.block.BlockStorage;
 import io.github.pylonmc.rebar.gametest.GameTestConfig;
 import io.github.pylonmc.rebar.test.RebarTest;
 import io.github.pylonmc.rebar.test.base.GameTest;
@@ -23,9 +24,7 @@ public class RebarItemStackInterfaceTest extends GameTest {
 
                     Block block = test.getWorld().getBlockAt(test.location());
                     block.setType(Material.BREWING_STAND);
-                    Bukkit.getPluginManager().callEvent(
-                            new BrewingStandFuelEvent(block, OminousBlazePower.STACK, 1));
-
+                    Bukkit.getPluginManager().callEvent(new BrewingStandFuelEvent(block, OminousBlazePower.STACK, 1));
                 })
                 .build());
     }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/recipe/CraftingTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/recipe/CraftingTest.java
@@ -3,7 +3,7 @@ package io.github.pylonmc.rebar.test.test.recipe;
 import io.github.pylonmc.rebar.recipe.RecipeType;
 import io.github.pylonmc.rebar.test.RebarTest;
 import io.github.pylonmc.rebar.test.base.SyncTest;
-import io.github.pylonmc.rebar.test.item.Items;
+import io.github.pylonmc.rebar.test.item.TestItems;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -18,7 +18,7 @@ public class CraftingTest extends SyncTest {
 
     @Override
     protected void test() {
-        ItemStack stickyStick = Items.STICKY_STICK_STACK;
+        ItemStack stickyStick = TestItems.STICKY_STICK_STACK;
         ItemStack diamond = new ItemStack(Material.DIAMOND);
         ItemStack nothing = new ItemStack(Material.AIR);
         ItemStack normalStick = new ItemStack(Material.STICK);

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/recipe/FurnaceTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/recipe/FurnaceTest.java
@@ -4,7 +4,7 @@ import io.github.pylonmc.rebar.gametest.GameTestConfig;
 import io.github.pylonmc.rebar.recipe.RecipeType;
 import io.github.pylonmc.rebar.test.RebarTest;
 import io.github.pylonmc.rebar.test.base.GameTest;
-import io.github.pylonmc.rebar.test.item.Items;
+import io.github.pylonmc.rebar.test.item.TestItems;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.Furnace;
@@ -19,7 +19,7 @@ public class FurnaceTest extends GameTest {
         super(new GameTestConfig.Builder(RebarTest.key("furnace_test"))
                 .size(0)
                 .setUp(test -> {
-                    ItemStack stickyStick = Items.STICKY_STICK_STACK;
+                    ItemStack stickyStick = TestItems.STICKY_STICK_STACK;
                     ItemStack diamond = new ItemStack(Material.DIAMOND);
                     RecipeType.VANILLA_FURNACE.addRecipe(new FurnaceRecipe(
                             RebarTest.key("sticky_stick_furnace"),

--- a/test/src/main/java/io/github/pylonmc/rebar/test/util/TestUtil.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/util/TestUtil.java
@@ -99,6 +99,8 @@ public final class TestUtil {
                         throw new RuntimeException(e);
                     }
                 }
+            } else {
+                chunk.setForceLoaded(true);
             }
 
             return chunk;
@@ -145,7 +147,10 @@ public final class TestUtil {
     @CheckReturnValue
     public static @NotNull CompletableFuture<Void> loadChunk(@NotNull Chunk chunk) {
         return runAsync(() -> {
-            runSync(() -> chunk.load()).join();
+            runSync(() -> {
+                chunk.load();
+                chunk.setForceLoaded(true);
+            }).join();
             waitUntil(chunk::isLoaded).join();
         });
     }
@@ -154,7 +159,10 @@ public final class TestUtil {
     public static @NotNull CompletableFuture<Void> unloadChunk(@NotNull Chunk chunk) {
         return runAsync(() -> {
             ChunkPosition chunkPosition = new ChunkPosition(chunk);
-            runSync(() -> chunk.unload()).join();
+            runSync(() -> {
+                chunk.setForceLoaded(false);
+                chunk.unload();
+            }).join();
             waitUntil(() -> !chunkPosition.isLoaded()).join();
         });
     }


### PR DESCRIPTION
- Fixes tests failing & succeeding inconsistently due to chunk (un)loading
- Adds log line for when tests start
- Suppress intentional error stack traces
- Fix some tests leaving blocks that impact other tests (looking at you ticking err block test)
- Renames the various core registration classes in rebar-test to Test<Type> instead of just <Type> for consistency (and also to avoid confusion with nms classes)
- changes the entity error test to use damage entity instead of player interact because passing null to the player interact caused a lot of unintended exceptions because null player is illegal
