### PR TITLE
Replace Entity Lib & PacketEvents

### DIFF
--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessorImpl.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessorImpl.kt
@@ -2,8 +2,11 @@ package io.github.pylonmc.rebar.nms
 
 import com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent
 import io.github.pylonmc.rebar.async.PlayerScope
+import io.github.pylonmc.rebar.block.RebarBlock
+import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity
 import io.github.pylonmc.rebar.i18n.PlayerTranslationHandler
 import io.github.pylonmc.rebar.i18n.packet.PlayerPacketHandler
+import io.github.pylonmc.rebar.nms.entity.BlockTextureEntityImpl
 import io.github.pylonmc.rebar.nms.recipe.HandlerRecipeBookClick
 import io.papermc.paper.adventure.PaperAdventure
 import kotlinx.coroutines.Dispatchers
@@ -176,4 +179,6 @@ object NmsAccessorImpl : NmsAccessor {
         val id = entity.entityId
         return (entity.world as CraftWorld).handle.chunkSource.chunkMap.entityMap.get(id)?.seenBy?.isNotEmpty() ?: false
     }
+
+    override fun createBlockTextureEntity(block: RebarBlock): BlockTextureEntity = BlockTextureEntityImpl(block)
 }

--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
@@ -1,0 +1,317 @@
+package io.github.pylonmc.rebar.nms.entity
+
+import com.mojang.math.MatrixUtil
+import io.github.pylonmc.rebar.Rebar
+import io.github.pylonmc.rebar.block.RebarBlock
+import io.github.pylonmc.rebar.culling.BlockCullingEngine
+import io.github.pylonmc.rebar.entity.display.transform.TransformUtil.toMatrix
+import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity
+import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity.Companion.MAX_SCALE_INCREASE
+import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity.Companion.SCALE_DISTANCE_INCREASE
+import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity.Companion.SCALE_DISTANCE_THRESHOLD
+import io.github.pylonmc.rebar.util.delayTicks
+import kotlinx.coroutines.launch
+import net.minecraft.network.protocol.Packet
+import net.minecraft.network.protocol.game.ClientboundAddEntityPacket
+import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket
+import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket
+import net.minecraft.network.syncher.EntityDataAccessor
+import net.minecraft.network.syncher.EntityDataSerializers
+import net.minecraft.network.syncher.SyncedDataHolder
+import net.minecraft.network.syncher.SynchedEntityData
+import net.minecraft.util.Mth
+import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.EntityType
+import net.minecraft.world.entity.Pose
+import net.minecraft.world.item.ItemDisplayContext
+import net.minecraft.world.phys.Vec3
+import org.bukkit.Bukkit
+import org.bukkit.Color
+import org.bukkit.craftbukkit.entity.CraftPlayer
+import org.bukkit.craftbukkit.inventory.CraftItemStack
+import org.bukkit.entity.Display
+import org.bukkit.entity.ItemDisplay
+import org.bukkit.inventory.ItemStack
+import org.bukkit.util.Transformation
+import org.joml.Matrix3f
+import org.joml.Matrix4f
+import org.joml.Quaternionf
+import org.joml.Vector3f
+import org.joml.Vector3fc
+import java.util.Optional
+import java.util.UUID
+import kotlin.math.abs
+import kotlin.math.min
+
+import net.minecraft.util.Brightness as NmsBrightness
+import net.minecraft.world.entity.Display as NmsDisplay
+import net.minecraft.world.item.ItemStack as NmsItemStack
+
+class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
+    override val block: RebarBlock
+    override var id: Int
+    override var uuid: UUID
+    override val viewers: MutableSet<UUID> = mutableSetOf()
+
+    override var isSpawned: Boolean = false
+
+    private val entityData: SynchedEntityData
+    private val trackedDataValues: List<SynchedEntityData.DataValue<*>>
+    private val refreshDataValues: List<SynchedEntityData.DataValue<*>>
+    private val lastScaleIncreases: MutableMap<UUID, Float> = mutableMapOf()
+
+    /**
+     * The translation needed to center scaling on the bounding box center instead of the block center.
+     * This is needed so that the scaling of non-full blocks (like slabs) scales around the correct point.
+     * The bounding box is unlikely to change often, so we cache the translation and only recalculate it every 5 seconds when requested.
+     */
+    private var scaleTranslation = Vector3f()
+        get() {
+            if (System.currentTimeMillis() - translationTimestamp > 5000) {
+                field = calculateScaleTranslation()
+                translationTimestamp = System.currentTimeMillis()
+            }
+            return field
+        }
+    private var translationTimestamp = 0L
+
+    constructor(block: RebarBlock) {
+        this.block = block
+        this.id = Bukkit.getUnsafe().nextEntityId()
+        this.uuid = Mth.createInsecureUUID(Entity.SHARED_RANDOM)
+        this.entityData = EntityDataAccess.fakedDataBuilder(this, NmsDisplay.ItemDisplay::class.java).apply {
+            define(EntityDataAccess.ENTITY_DATA_SHARED_FLAGS_ID, 0.toByte())
+            define(EntityDataAccess.ENTITY_DATA_AIR_SUPPLY_ID, 300)
+            define(EntityDataAccess.ENTITY_DATA_CUSTOM_NAME_VISIBLE, false)
+            define(EntityDataAccess.ENTITY_DATA_CUSTOM_NAME, Optional.empty())
+            define(EntityDataAccess.ENTITY_DATA_SILENT, false)
+            define(EntityDataAccess.ENTITY_DATA_NO_GRAVITY, false)
+            define(EntityDataAccess.ENTITY_DATA_POSE, Pose.STANDING)
+            define(EntityDataAccess.ENTITY_DATA_TICKS_FROZEN, 0)
+
+            define(EntityDataAccess.DISPLAY_DATA_POS_ROT_INTERPOLATION_DURATION_ID, 0)
+            define(EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID, 0)
+            define(EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID, 0)
+            define(EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID, Vector3f())
+            define(EntityDataAccess.DISPLAY_DATA_SCALE_ID, Vector3f(1.0F, 1.0F, 1.0F))
+            define(EntityDataAccess.DISPLAY_DATA_RIGHT_ROTATION_ID, Quaternionf())
+            define(EntityDataAccess.DISPLAY_DATA_LEFT_ROTATION_ID, Quaternionf())
+            define(EntityDataAccess.DISPLAY_DATA_BILLBOARD_RENDER_CONSTRAINTS_ID, 0.toByte())
+            define(EntityDataAccess.DISPLAY_DATA_BRIGHTNESS_OVERRIDE_ID, -1)
+            define(EntityDataAccess.DISPLAY_DATA_VIEW_RANGE_ID, 1.0F)
+            define(EntityDataAccess.DISPLAY_DATA_SHADOW_RADIUS_ID, 0.0F)
+            define(EntityDataAccess.DISPLAY_DATA_SHADOW_STRENGTH_ID, 1.0F)
+            define(EntityDataAccess.DISPLAY_DATA_WIDTH_ID, 0.0F)
+            define(EntityDataAccess.DISPLAY_DATA_HEIGHT_ID, 0.0F)
+            define(EntityDataAccess.DISPLAY_DATA_GLOW_COLOR_OVERRIDE_ID, -1)
+
+            define(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_STACK_ID, NmsItemStack.EMPTY)
+            define(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_DISPLAY_ID, ItemDisplayContext.NONE.id)
+        }.build()
+        this.trackedDataValues = entityData.nonDefaultValues ?: listOf()
+        this.refreshDataValues = trackedDataValues.filter { it.id == EntityDataAccess.DISPLAY_DATA_SCALE_ID.id || it.id == EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID.id}
+    }
+
+    override var transformation: Transformation
+        get() = Transformation(
+            Vector3f(entityData.get(EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID)),
+            Quaternionf(entityData.get(EntityDataAccess.DISPLAY_DATA_LEFT_ROTATION_ID)),
+            Vector3f(entityData.get(EntityDataAccess.DISPLAY_DATA_SCALE_ID)),
+            Quaternionf(entityData.get(EntityDataAccess.DISPLAY_DATA_RIGHT_ROTATION_ID))
+        )
+        set(value) {
+            entityData.set(EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID, value.translation)
+            entityData.set(EntityDataAccess.DISPLAY_DATA_LEFT_ROTATION_ID, value.leftRotation)
+            entityData.set(EntityDataAccess.DISPLAY_DATA_SCALE_ID, value.scale)
+            entityData.set(EntityDataAccess.DISPLAY_DATA_RIGHT_ROTATION_ID, value.rightRotation)
+        }
+    override var transformationMatrix: Matrix4f
+        get() = transformation.toMatrix()
+        set(value) {
+            val f = 1.0F / value.m33();
+            val decomposed = MatrixUtil.svdDecompose(Matrix3f(value).scale(f))
+            entityData.set(EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID, value.getTranslation(Vector3f()).mul(f))
+            entityData.set(EntityDataAccess.DISPLAY_DATA_LEFT_ROTATION_ID, Quaternionf(decomposed.left))
+            entityData.set(EntityDataAccess.DISPLAY_DATA_SCALE_ID, Vector3f(decomposed.middle))
+            entityData.set(EntityDataAccess.DISPLAY_DATA_RIGHT_ROTATION_ID, Quaternionf(decomposed.right))
+        }
+
+    override var interpolationDelay: Int
+        get() = entityData.get(EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID)
+        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID, value)
+    override var interpolationDuration: Int
+        get() = entityData.get(EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID)
+        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID, value)
+    override var teleportDuration: Int
+        get() = entityData.get(EntityDataAccess.DISPLAY_DATA_POS_ROT_INTERPOLATION_DURATION_ID)
+        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_POS_ROT_INTERPOLATION_DURATION_ID, value)
+
+    override var shadowRadius: Float
+        get() = entityData.get(EntityDataAccess.DISPLAY_DATA_SHADOW_RADIUS_ID)
+        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_SHADOW_RADIUS_ID, value)
+    override var shadowStrength: Float
+        get() = entityData.get(EntityDataAccess.DISPLAY_DATA_SHADOW_STRENGTH_ID)
+        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_SHADOW_STRENGTH_ID, value)
+
+    override var displayWidth: Float
+        get() = entityData.get(EntityDataAccess.DISPLAY_DATA_WIDTH_ID)
+        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_WIDTH_ID, value)
+    override var displayHeight: Float
+        get() = entityData.get(EntityDataAccess.DISPLAY_DATA_HEIGHT_ID)
+        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_HEIGHT_ID, value)
+    override var viewRange: Float
+        get() = entityData.get(EntityDataAccess.DISPLAY_DATA_VIEW_RANGE_ID)
+        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_VIEW_RANGE_ID, value)
+
+    override var glowColorOverride: Color?
+        get() = when(val color = entityData.get(EntityDataAccess.DISPLAY_DATA_GLOW_COLOR_OVERRIDE_ID)) {
+            -1 -> null
+            else -> Color.fromRGB(color and 16777215)
+        }
+        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_GLOW_COLOR_OVERRIDE_ID, value?.asRGB() ?: -1)
+    override var billboard: Display.Billboard
+        get() = Display.Billboard.entries[entityData.get(EntityDataAccess.DISPLAY_DATA_BILLBOARD_RENDER_CONSTRAINTS_ID).toInt()]
+        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_BILLBOARD_RENDER_CONSTRAINTS_ID, NmsDisplay.BillboardConstraints.valueOf(value.name).ordinal.toByte())
+    override var brightness: Display.Brightness?
+        get() = when (val brightness = entityData.get(EntityDataAccess.DISPLAY_DATA_BRIGHTNESS_OVERRIDE_ID)) {
+            -1 -> null
+            else -> Display.Brightness(NmsBrightness.block(brightness), NmsBrightness.sky(brightness))
+        }
+        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_BRIGHTNESS_OVERRIDE_ID, value?.let { NmsBrightness.pack(value.blockLight, value.skyLight) } ?: -1)
+
+    override var itemStack: ItemStack?
+        get() = entityData.get(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_STACK_ID).asBukkitCopy()
+        set(value) = entityData.set(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_STACK_ID, (value as? CraftItemStack)?.handle ?: NmsItemStack.EMPTY)
+    override var itemDisplayTransform: ItemDisplay.ItemDisplayTransform
+        get() = ItemDisplay.ItemDisplayTransform.entries[entityData.get(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_DISPLAY_ID).toInt()]
+        set(value) = entityData.set(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_DISPLAY_ID, value.ordinal.toByte())
+
+    private fun calculateScaleTranslation(): Vector3f {
+        val boundingBox = block.block.boundingBox
+        val blockX = block.block.x
+        val blockY = block.block.y
+        val blockZ = block.block.z
+
+        val bbCenterX = (boundingBox.minX + boundingBox.maxX) / 2.0 - blockX
+        val bbCenterY = (boundingBox.minY + boundingBox.maxY) / 2.0 - blockY
+        val bbCenterZ = (boundingBox.minZ + boundingBox.maxZ) / 2.0 - blockZ
+
+        return Vector3f(
+            (bbCenterX - 0.5).toFloat(),
+            (bbCenterY - 0.5).toFloat(),
+            (bbCenterZ - 0.5).toFloat()
+        )
+    }
+
+    override fun onSyncedDataUpdated(p0: EntityDataAccessor<*>) {}
+    override fun onSyncedDataUpdated(p0: List<SynchedEntityData.DataValue<*>>) {}
+
+    private fun createDataPacket(playerId: UUID, distanceSquared: Double, trackedData: List<SynchedEntityData.DataValue<*>>, refresh: Boolean) : ClientboundSetEntityDataPacket? {
+        var trackedData = trackedData
+        val scaleIncrease = min((distanceSquared * SCALE_DISTANCE_INCREASE).toFloat(), MAX_SCALE_INCREASE)
+        val lastScaleIncrease = lastScaleIncreases[playerId] ?: 0f
+        if (abs(scaleIncrease - lastScaleIncrease) < SCALE_DISTANCE_THRESHOLD && refresh) {
+            return null
+        }
+
+        lastScaleIncreases[playerId] = scaleIncrease
+        var scale: Vector3f? = null
+        trackedData = trackedData.map { data ->
+            if (data.id == EntityDataAccess.DISPLAY_DATA_SCALE_ID.id) {
+                scale = Vector3f(scaleIncrease).add(data.value as Vector3fc)
+                SynchedEntityData.DataValue(data.id, EntityDataSerializers.VECTOR3, scale)
+            } else {
+                data
+            }
+        }
+
+        return ClientboundSetEntityDataPacket(id, trackedData.map { data ->
+            if (data.id == EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID.id && scale != null) {
+                SynchedEntityData.DataValue(data.id, EntityDataSerializers.VECTOR3, Vector3f(
+                    scaleTranslation.x * (1 - scale.x),
+                    scaleTranslation.y * (1 - scale.y),
+                    scaleTranslation.z * (1 - scale.z)
+                ))
+            } else {
+                data
+            }
+        })
+    }
+
+    private fun sendPacket(playerId: UUID, packet: Packet<*>) {
+        val player = (Bukkit.getPlayer(playerId) as CraftPlayer).handle
+        player.connection.send(packet)
+    }
+
+    private fun addViewer(playerId: UUID, distanceSquared: Double) {
+        sendPacket(playerId, ClientboundAddEntityPacket(
+            id, uuid, block.block.x + 0.5, block.block.y + 0.5, block.block.z + 0.5, 0f, 0f,
+            EntityType.ITEM_DISPLAY, 0, Vec3(0.0, 0.0, 0.0), 0.0
+        ))
+        sendPacket(playerId, createDataPacket(playerId, distanceSquared, trackedDataValues, false) ?: return)
+    }
+
+    override fun addOrRefreshViewer(playerId: UUID, distanceSquared: Double) {
+        if (this.viewers.add(playerId)) {
+            addViewer(playerId, distanceSquared)
+        } else {
+            refreshViewer(playerId, distanceSquared)
+        }
+    }
+
+    override fun refreshViewer(playerId: UUID, distanceSquared: Double) {
+        sendPacket(playerId, createDataPacket(playerId, distanceSquared, refreshDataValues, true) ?: return)
+    }
+
+    override fun hasViewer(playerId: UUID) = playerId in this.viewers
+
+    override fun removeViewer(playerId: UUID) {
+        if (this.viewers.remove(playerId)) {
+            sendPacket(playerId, ClientboundRemoveEntitiesPacket(id))
+        }
+    }
+
+    override fun removeAllViewers() {
+        for (viewer in viewers.toSet()) {
+            removeViewer(viewer)
+        }
+    }
+
+    override fun spawn() {
+        if (isSpawned) return
+        isSpawned = true
+        for (playerId in viewers) {
+            addViewer(playerId, distanceSquared(this, playerId))
+        }
+    }
+
+    companion object {
+
+        @JvmSynthetic
+        internal val tickJob = Rebar.scope.launch {
+            while (true) {
+                delayTicks(1)
+                for (blockTextureOctree in BlockCullingEngine.blockTextureOctrees.values) {
+                    for (block in blockTextureOctree.allEntries()) {
+                        val entity = block.blockTextureEntity as? BlockTextureEntityImpl ?: continue
+                        if (entity.viewers.isEmpty()) continue
+
+                        val trackedData = entity.entityData.packDirty() ?: continue
+                        for (playerId in entity.viewers) {
+                            entity.sendPacket(playerId, entity.createDataPacket(playerId, distanceSquared(entity, playerId), trackedData, false) ?: continue)
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun distanceSquared(entity: BlockTextureEntityImpl, playerId: UUID): Double {
+            val player = Bukkit.getPlayer(playerId) ?: return 0.0
+            val block = entity.block.block
+            val dx = player.x - block.x
+            val dy = player.y - block.y
+            val dz = player.z - block.z
+            return dx * dx + dy * dy + dz * dz
+        }
+    }
+}

--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
@@ -56,8 +56,17 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
     override var isSpawned: Boolean = false
 
     private val entityData: SynchedEntityData
+
+    /**
+     * The data to sync when the entity is spawned in
+     */
     private val trackedDataValues: List<SynchedEntityData.DataValue<*>>
+
+    /**
+     * The data to sync on player refresh
+     */
     private val refreshDataValues: List<SynchedEntityData.DataValue<*>>
+
     private val lastScaleIncreases: MutableMap<UUID, Float> = mutableMapOf()
 
     /**
@@ -80,6 +89,7 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
         this.id = Bukkit.getUnsafe().nextEntityId()
         this.uuid = Mth.createInsecureUUID(Entity.SHARED_RANDOM)
         this.entityData = EntityDataAccess.fakedDataBuilder(this, NmsDisplay.ItemDisplay::class.java).apply {
+            // An ItemDisplay's class hierarchy is Entity -> Display -> ItemDisplay, so to fake it we need to define all the data parameters for all 3 classes identically
             define(EntityDataAccess.ENTITY_DATA_SHARED_FLAGS_ID, 0.toByte())
             define(EntityDataAccess.ENTITY_DATA_AIR_SUPPLY_ID, 300)
             define(EntityDataAccess.ENTITY_DATA_CUSTOM_NAME_VISIBLE, false)
@@ -290,9 +300,10 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
         @JvmSynthetic
         internal val tickJob = Rebar.scope.launch {
             while (true) {
+                // TODO: Consider making this configurable & async, the delay is the delay between making a change to the entity & it being reflected to the clients
                 delayTicks(1)
                 for (blockTextureOctree in BlockCullingEngine.blockTextureOctrees.values) {
-                    for (block in blockTextureOctree.allEntries()) {
+                    for (block in blockTextureOctree) {
                         val entity = block.blockTextureEntity as? BlockTextureEntityImpl ?: continue
                         if (entity.viewers.isEmpty()) continue
 

--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
@@ -70,14 +70,14 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
     private val lastScaleIncreases: MutableMap<UUID, Float> = mutableMapOf()
 
     /**
-     * The translation needed to center scaling on the bounding box center instead of the block center.
-     * This is needed so that the scaling of non-full blocks (like slabs) scales around the correct point.
+     * The transformation of the texture entity needs to be centered on the bounding box of the block instead of the block center.
+     * This is needed so that the scaling of non-full blocks (like slabs) scales around the correct point to combat z-fighting.
      * The bounding box is unlikely to change often, so we cache the translation and only recalculate it every 5 seconds when requested.
      */
-    private var scaleTranslation = Vector3f()
+    private var centerTranslation = Vector3f()
         get() {
             if (System.currentTimeMillis() - translationTimestamp > 5000) {
-                field = calculateScaleTranslation()
+                field = calculateCenterTranslation()
                 translationTimestamp = System.currentTimeMillis()
             }
             return field
@@ -196,7 +196,7 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
         get() = ItemDisplay.ItemDisplayTransform.entries[entityData.get(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_DISPLAY_ID).toInt()]
         set(value) = entityData.set(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_DISPLAY_ID, value.ordinal.toByte())
 
-    private fun calculateScaleTranslation(): Vector3f {
+    private fun calculateCenterTranslation(): Vector3f {
         val boundingBox = block.block.boundingBox
         val blockX = block.block.x
         val blockY = block.block.y
@@ -238,9 +238,9 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
         return ClientboundSetEntityDataPacket(id, trackedData.map { data ->
             if (data.id == EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID.id && scale != null) {
                 SynchedEntityData.DataValue(data.id, EntityDataSerializers.VECTOR3, Vector3f(
-                    scaleTranslation.x * (1 - scale.x),
-                    scaleTranslation.y * (1 - scale.y),
-                    scaleTranslation.z * (1 - scale.z)
+                    centerTranslation.x * (1 - scale.x),
+                    centerTranslation.y * (1 - scale.y),
+                    centerTranslation.z * (1 - scale.z)
                 ))
             } else {
                 data

--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/EntityDataAccess.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/EntityDataAccess.kt
@@ -1,0 +1,97 @@
+package io.github.pylonmc.rebar.nms.entity
+
+import com.google.gson.internal.reflect.ReflectionHelper.getAccessor
+import io.github.pylonmc.rebar.Rebar
+import net.minecraft.network.chat.Component
+import net.minecraft.network.syncher.EntityDataAccessor
+import net.minecraft.network.syncher.SyncedDataHolder
+import net.minecraft.network.syncher.SynchedEntityData
+import net.minecraft.util.ClassTreeIdRegistry
+import net.minecraft.world.entity.Display
+import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.Pose
+import net.minecraft.world.item.ItemStack
+import org.joml.Quaternionfc
+import org.joml.Vector3fc
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.VarHandle
+import java.util.*
+
+object EntityDataAccess {
+
+    val ENTITY_DATA_SHARED_FLAGS_ID: EntityDataAccessor<Byte> = getAccessor("DATA_SHARED_FLAGS_ID", Entity::class.java)
+    val ENTITY_DATA_AIR_SUPPLY_ID: EntityDataAccessor<Int> = getAccessor("DATA_AIR_SUPPLY_ID", Entity::class.java)
+    val ENTITY_DATA_CUSTOM_NAME_VISIBLE: EntityDataAccessor<Boolean> = getAccessor("DATA_CUSTOM_NAME_VISIBLE", Entity::class.java)
+    val ENTITY_DATA_CUSTOM_NAME: EntityDataAccessor<Optional<Component>> = getAccessor("DATA_CUSTOM_NAME", Entity::class.java)
+    val ENTITY_DATA_SILENT: EntityDataAccessor<Boolean> = getAccessor("DATA_SILENT", Entity::class.java)
+    val ENTITY_DATA_NO_GRAVITY: EntityDataAccessor<Boolean> = getAccessor("DATA_NO_GRAVITY", Entity::class.java)
+    val ENTITY_DATA_POSE: EntityDataAccessor<Pose> = getAccessor("DATA_POSE", Entity::class.java)
+    val ENTITY_DATA_TICKS_FROZEN: EntityDataAccessor<Int> = getAccessor("DATA_TICKS_FROZEN", Entity::class.java)
+
+    val DISPLAY_DATA_POS_ROT_INTERPOLATION_DURATION_ID: EntityDataAccessor<Int> = getAccessor("DATA_POS_ROT_INTERPOLATION_DURATION_ID", Display::class.java)
+    val DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID: EntityDataAccessor<Int> = getAccessor("DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID", Display::class.java)
+    val DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID: EntityDataAccessor<Int> = getAccessor("DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID", Display::class.java)
+    val DISPLAY_DATA_TRANSLATION_ID: EntityDataAccessor<Vector3fc> = getAccessor("DATA_TRANSLATION_ID", Display::class.java)
+    val DISPLAY_DATA_SCALE_ID: EntityDataAccessor<Vector3fc> = getAccessor("DATA_SCALE_ID", Display::class.java)
+    val DISPLAY_DATA_RIGHT_ROTATION_ID: EntityDataAccessor<Quaternionfc> = getAccessor("DATA_RIGHT_ROTATION_ID", Display::class.java)
+    val DISPLAY_DATA_LEFT_ROTATION_ID: EntityDataAccessor<Quaternionfc> = getAccessor("DATA_LEFT_ROTATION_ID", Display::class.java)
+    val DISPLAY_DATA_BILLBOARD_RENDER_CONSTRAINTS_ID: EntityDataAccessor<Byte> = getAccessor("DATA_BILLBOARD_RENDER_CONSTRAINTS_ID", Display::class.java)
+    val DISPLAY_DATA_BRIGHTNESS_OVERRIDE_ID: EntityDataAccessor<Int> = getAccessor("DATA_BRIGHTNESS_OVERRIDE_ID", Display::class.java)
+    val DISPLAY_DATA_VIEW_RANGE_ID: EntityDataAccessor<Float> = getAccessor("DATA_VIEW_RANGE_ID", Display::class.java)
+    val DISPLAY_DATA_SHADOW_RADIUS_ID: EntityDataAccessor<Float> = getAccessor("DATA_SHADOW_RADIUS_ID", Display::class.java)
+    val DISPLAY_DATA_SHADOW_STRENGTH_ID: EntityDataAccessor<Float> = getAccessor("DATA_SHADOW_STRENGTH_ID", Display::class.java)
+    val DISPLAY_DATA_WIDTH_ID: EntityDataAccessor<Float> = getAccessor("DATA_WIDTH_ID", Display::class.java)
+    val DISPLAY_DATA_HEIGHT_ID: EntityDataAccessor<Float> = getAccessor("DATA_HEIGHT_ID", Display::class.java)
+    val DISPLAY_DATA_GLOW_COLOR_OVERRIDE_ID: EntityDataAccessor<Int> = getAccessor("DATA_GLOW_COLOR_OVERRIDE_ID", Display::class.java)
+    
+    val ITEM_DISPLAY_DATA_ITEM_STACK_ID: EntityDataAccessor<ItemStack> = getAccessor("DATA_ITEM_STACK_ID", Display.ItemDisplay::class.java)
+    val ITEM_DISPLAY_DATA_ITEM_DISPLAY_ID: EntityDataAccessor<Byte> = getAccessor("DATA_ITEM_DISPLAY_ID", Display.ItemDisplay::class.java)
+
+    private val ID_REGISTRY: ClassTreeIdRegistry = run {
+        try {
+            val field = SynchedEntityData::class.java.getDeclaredField("ID_REGISTRY")
+            field.isAccessible = true
+            field[null] as ClassTreeIdRegistry
+        } catch (t: Throwable) {
+            Rebar.logger.severe("Failed to access SynchedEntityData ID registry!")
+            throw t
+        }
+    }
+
+    private val ITEMS_HANDLE: MethodHandle = run {
+        try {
+            val field = SynchedEntityData.Builder::class.java.getDeclaredField("itemsById")
+            field.isAccessible = true
+            val lookup = MethodHandles.privateLookupIn(SynchedEntityData.Builder::class.java, MethodHandles.lookup())
+            lookup.unreflectSetter(field)
+        } catch (t: Throwable) {
+            Rebar.logger.severe("Failed to access SynchedEntityData.Builder itemsById field!")
+            throw t
+        }
+    }
+
+    internal fun <T : SyncedDataHolder> fakedDataBuilder(real: SyncedDataHolder, faked: Class<T>) : SynchedEntityData.Builder {
+        try {
+            val builder = SynchedEntityData.Builder(real)
+            val fakedSize = ID_REGISTRY.getCount(faked)
+            ITEMS_HANDLE.invoke(builder, arrayOfNulls<SynchedEntityData.DataItem<*>>(fakedSize))
+            return builder
+        } catch (t: Throwable) {
+            Rebar.logger.severe("Failed to create sized entity data builder")
+            throw t
+        }
+    }
+
+    private fun <T : Any> getAccessor(name: String, clazz: Class<*>) : EntityDataAccessor<T> {
+        try {
+            val field = clazz.getDeclaredField(name)
+            field.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            return field[null] as EntityDataAccessor<T>
+        } catch (t: Throwable) {
+            Rebar.logger.severe("Failed to access entity data '$name'!")
+            throw t
+        }
+    }
+}

--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/EntityDataAccess.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/EntityDataAccess.kt
@@ -1,6 +1,5 @@
 package io.github.pylonmc.rebar.nms.entity
 
-import com.google.gson.internal.reflect.ReflectionHelper.getAccessor
 import io.github.pylonmc.rebar.Rebar
 import net.minecraft.network.chat.Component
 import net.minecraft.network.syncher.EntityDataAccessor
@@ -15,7 +14,6 @@ import org.joml.Quaternionfc
 import org.joml.Vector3fc
 import java.lang.invoke.MethodHandle
 import java.lang.invoke.MethodHandles
-import java.lang.invoke.VarHandle
 import java.util.*
 
 object EntityDataAccess {
@@ -71,6 +69,10 @@ object EntityDataAccess {
         }
     }
 
+    /**
+     * When creating a packet entity based on a real entity, you need a builder scaled for the real entity type but backed by the packet based implementation
+     * @return A [SynchedEntityData.Builder] scaled for the real entity type but backed by the packet based implementation
+     */
     internal fun <T : SyncedDataHolder> fakedDataBuilder(real: SyncedDataHolder, faked: Class<T>) : SynchedEntityData.Builder {
         try {
             val builder = SynchedEntityData.Builder(real)

--- a/rebar/build.gradle.kts
+++ b/rebar/build.gradle.kts
@@ -41,8 +41,6 @@ dependencies {
 
     paperLibraryApi("xyz.xenondevs.invui:invui:2.0.0-beta.5")
     paperLibraryApi("xyz.xenondevs.invui:invui-kotlin:2.0.0-beta.5")
-    implementation("com.github.Tofaa2.EntityLib:spigot:2.4.11")
-    implementation("com.github.retrooper:packetevents-spigot:2.11.2")
     implementation("info.debatty:java-string-similarity:2.0.0")
     implementation("org.bstats:bstats-bukkit:2.2.1")
     paperLibrary("com.github.ben-manes.caffeine:caffeine:3.2.2")
@@ -144,8 +142,6 @@ tasks.shadowJar {
     exclude("org/intellij/lang/annotations/**")
     exclude("org/jetbrains/annotations/**")
 
-    relocate("com.github.retrooper.packetevents", "io.github.pylonmc.rebar.packetevents")
-    relocate("me.tofaa.entitylib", "io.github.pylonmc.rebar.entitylib")
     relocate("org.bstats", "io.github.pylonmc.rebar.bstats")
 
     archiveBaseName = "rebar"

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/Rebar.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/Rebar.kt
@@ -2,8 +2,6 @@
 
 package io.github.pylonmc.rebar
 
-import com.github.retrooper.packetevents.PacketEvents
-import com.github.retrooper.packetevents.event.PacketListenerPriority
 import io.github.pylonmc.rebar.addon.RebarAddon
 import io.github.pylonmc.rebar.async.BukkitMainThreadDispatcher
 import io.github.pylonmc.rebar.async.ChunkScope
@@ -44,36 +42,29 @@ import io.github.pylonmc.rebar.recipe.RebarRecipeListener
 import io.github.pylonmc.rebar.recipe.RecipeCompletion
 import io.github.pylonmc.rebar.recipe.RecipeType
 import io.github.pylonmc.rebar.registry.RebarRegistry
-import io.github.pylonmc.rebar.resourcepack.armor.ArmorTextureEngine
 import io.github.pylonmc.rebar.util.delayTicks
 import io.github.pylonmc.rebar.util.mergeGlobalConfig
 import io.github.pylonmc.rebar.waila.Waila
-import io.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder
 import io.papermc.paper.ServerBuildInfo
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import me.tofaa.entitylib.APIConfig
-import me.tofaa.entitylib.EntityIdProvider
-import me.tofaa.entitylib.EntityLib
-import me.tofaa.entitylib.spigot.SpigotEntityLibPlatform
 import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
 import org.bukkit.configuration.file.YamlConfiguration
 import org.bukkit.entity.BlockDisplay
-import org.bukkit.entity.Display
 import org.bukkit.entity.FallingBlock
 import org.bukkit.entity.ItemDisplay
-import org.bukkit.inventory.PlayerInventory
 import org.bukkit.permissions.Permission
 import org.bukkit.permissions.PermissionDefault
 import org.bukkit.plugin.java.JavaPlugin
+import org.jetbrains.annotations.ApiStatus
 import xyz.xenondevs.invui.InvUI
 import xyz.xenondevs.invui.i18n.Languages
-import java.util.Locale
+import java.util.*
 import kotlin.io.path.*
 
 /**
@@ -85,18 +76,15 @@ object Rebar : JavaPlugin(), RebarAddon {
      * Ticks once per tick
      */
     @get:JvmSynthetic
-    internal val mainThreadDispatcher by lazy { BukkitMainThreadDispatcher(this, 1) }
+    @get:ApiStatus.Internal
+    val mainThreadDispatcher by lazy { BukkitMainThreadDispatcher(this, 1) }
 
     /**
      * By default, dispatches on the main thread
      */
     @get:JvmSynthetic
-    internal val scope by lazy { CoroutineScope(SupervisorJob() + mainThreadDispatcher) }
-
-    override fun onLoad() {
-        PacketEvents.setAPI(SpigotPacketEventsBuilder.build(this))
-        PacketEvents.getAPI().load()
-    }
+    @get:ApiStatus.Internal
+    val scope by lazy { CoroutineScope(SupervisorJob() + mainThreadDispatcher) }
 
     override fun onEnable() {
         val start = System.currentTimeMillis()
@@ -115,17 +103,6 @@ object Rebar : JavaPlugin(), RebarAddon {
 
         InvUI.getInstance().setPlugin(this)
         Languages.getInstance().enableServerSideTranslations(false) // we do our own
-
-        val packetEvents = PacketEvents.getAPI()
-        packetEvents.init()
-
-        val entityLibPlatform = SpigotEntityLibPlatform(this)
-        val entityLibSettings = APIConfig(packetEvents).tickTickables()
-        EntityLib.init(entityLibPlatform, entityLibSettings)
-        entityLibPlatform.entityIdProvider = EntityIdProvider { _, _ ->
-            @Suppress("DEPRECATION")
-            Bukkit.getUnsafe().nextEntityId()
-        }
 
         saveDefaultConfig()
         // Add any keys that are missing from global config - saveDefaultConfig will not do anything if config already present
@@ -395,7 +372,6 @@ object Rebar : JavaPlugin(), RebarAddon {
 
     override fun onDisable() {
         // Note: At this point all listeners have been unregistered
-        PacketEvents.getAPI().terminate()
         RebarMetrics.save()
         scope.cancel()
     }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/RebarBlock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/RebarBlock.kt
@@ -1,7 +1,5 @@
 package io.github.pylonmc.rebar.block
 
-import com.github.retrooper.packetevents.protocol.world.Location
-import com.github.retrooper.packetevents.util.Vector3f
 import io.github.pylonmc.rebar.Rebar
 import io.github.pylonmc.rebar.block.RebarBlock.Companion.rebarBlockTextureEntityKey
 import io.github.pylonmc.rebar.block.RebarBlock.Companion.register
@@ -26,17 +24,18 @@ import io.github.pylonmc.rebar.util.position.BlockPosition
 import io.github.pylonmc.rebar.util.position.position
 import io.github.pylonmc.rebar.util.rebarKey
 import io.github.pylonmc.rebar.waila.WailaDisplay
-import io.github.retrooper.packetevents.util.SpigotConversionUtil
 import io.papermc.paper.datacomponent.DataComponentTypes
-import me.tofaa.entitylib.meta.display.ItemDisplayMeta
 import net.kyori.adventure.key.Key
 import org.bukkit.*
 import org.bukkit.block.Block
+import org.bukkit.entity.Display
 import org.bukkit.entity.ItemDisplay
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataAdapterContext
 import org.bukkit.persistence.PersistentDataContainer
+import org.bukkit.util.Transformation
+import org.joml.Vector3f
 
 /**
  * Represents a Rebar block in the world.
@@ -80,8 +79,7 @@ open class RebarBlock private constructor(val block: Block) : Keyed {
      * you want to expose to resource packs for custom models/textures. If those properties change
      * you can call [refreshBlockTextureItem] to update the model accordingly.
      *
-     * Upon initialization the entity is set up by [setupBlockTexture] (which can be overridden),
-     * and modifications afterward can be done using [updateBlockTexture].
+     * Upon initialization the entity is set up by [setupBlockTexture] (which can be overridden).
      *
      * Being lazily initialized, if you do not access the entity directly it will only be created
      * when a player with `customBlockTextures` comes within range for the first time. This is to
@@ -92,9 +90,7 @@ open class RebarBlock private constructor(val block: Block) : Keyed {
         if (!RebarConfig.BlockTextureConfig.ENABLED || disableBlockTextureEntity) {
             null
         } else {
-            val entity = BlockTextureEntity(this)
-            val meta = entity.getEntityMeta(ItemDisplayMeta::class.java)
-            setupBlockTexture(entity, meta)
+            setupBlockTexture(NmsAccessor.instance.createBlockTextureEntity(this))
         }
     }
 
@@ -143,42 +139,30 @@ open class RebarBlock private constructor(val block: Block) : Keyed {
     open fun postInitialise() {}
 
     /**
-     * Used to initialize [blockTextureEntity], if you need to modify the entity post-initialization,
-     * use [updateBlockTexture].
+     * Used to initialize [blockTextureEntity].
      *
      * By default, this method sets the item display to be at the center of the block, using the
      * item returned by [getBlockTextureItem] (or a barrier if none is provided), set's its item
-     * model to air, making it invisible for players without a resource pack, scales it to
-     * 1.00085f in all directions to prevent z-fighting with the vanilla block model, and maxes its
-     * brightness. It sets the display type to be "fixed".
+     * model to air, making it invisible for players without a resource pack, scales in all
+     * directions to prevent z-fighting with the vanilla block model, and maxes its brightness.
+     * It sets the display type to be "fixed".
      */
-    protected open fun setupBlockTexture(entity: BlockTextureEntity, meta: ItemDisplayMeta): BlockTextureEntity = entity.apply {
+    protected open fun setupBlockTexture(entity: BlockTextureEntity): BlockTextureEntity = entity.apply {
         // TODO: Add a way to easily just change the transformation of the entity, without having to override this method entirely
-        entity.spawn(Location(this@RebarBlock.block.x + 0.5, this@RebarBlock.block.y + 0.5, this@RebarBlock.block.z + 0.5, 0f, 0f))
-
         val item = getBlockTextureItem() ?: ItemStack(Material.BARRIER)
         item.setData(DataComponentTypes.ITEM_MODEL, Key.key("air"))
-        meta.item = SpigotConversionUtil.fromBukkitItemStack(item)
-        meta.displayType = ItemDisplayMeta.DisplayType.FIXED
-        meta.brightnessOverride = 15 shl 4 or 15 shl 20;
-        meta.scale = Vector3f(
-            1 + BlockTextureEntity.BLOCK_OVERLAP_INCREASE,
-            1 + BlockTextureEntity.BLOCK_OVERLAP_INCREASE,
-            1 + BlockTextureEntity.BLOCK_OVERLAP_INCREASE
-        )
-        meta.width = 0f
-        meta.height = 0f
-    }
-
-    /**
-     * Use this method to make any changes to the block texture entity, such as changing its item,
-     * transformation, etc, after initialization. (see [setupBlockTexture])
-     */
-    protected fun updateBlockTexture(updater: (BlockTextureEntity, ItemDisplayMeta) -> Unit) {
-        blockTextureEntity?.let {
-            val meta = it.getEntityMeta(ItemDisplayMeta::class.java)
-            updater(it, meta)
+        itemStack = item
+        itemDisplayTransform = ItemDisplay.ItemDisplayTransform.FIXED
+        brightness = Display.Brightness(15, 15)
+        transformation = transformation.let {
+            Transformation(
+                it.translation,
+                it.leftRotation,
+                Vector3f(1 + BlockTextureEntity.BLOCK_OVERLAP_INCREASE),
+                it.rightRotation
+            )
         }
+        entity.spawn()
     }
 
     /**
@@ -196,10 +180,10 @@ open class RebarBlock private constructor(val block: Block) : Keyed {
      * [getBlockTextureItem], or a barrier if that returns null.
      */
     fun refreshBlockTextureItem() {
-        updateBlockTexture { _, meta ->
+        blockTextureEntity?.let {
             val item = getBlockTextureItem() ?: ItemStack(Material.BARRIER)
             item.setData(DataComponentTypes.ITEM_MODEL, Key.key("air"))
-            meta.item = SpigotConversionUtil.fromBukkitItemStack(item)
+            it.itemStack = item
         }
     }
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/debug/DebugWaxedWeatheredCutCopperStairs.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/debug/DebugWaxedWeatheredCutCopperStairs.kt
@@ -16,9 +16,7 @@ import io.github.pylonmc.rebar.item.builder.ItemStackBuilder
 import io.github.pylonmc.rebar.nms.NmsAccessor
 import io.github.pylonmc.rebar.util.position.position
 import io.github.pylonmc.rebar.util.rebarKey
-import io.github.retrooper.packetevents.util.SpigotConversionUtil
 import io.papermc.paper.datacomponent.DataComponentTypes
-import me.tofaa.entitylib.meta.display.ItemDisplayMeta
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component
 import org.bukkit.Material
@@ -92,7 +90,7 @@ internal class DebugWaxedWeatheredCutCopperStairs(stack: ItemStack)
                 pdc.set(
                     RebarBlock.rebarBlockTextureEntityKey,
                     RebarSerializers.ITEM_STACK_READABLE,
-                    SpigotConversionUtil.toBukkitItemStack(entity.getEntityMeta(ItemDisplayMeta::class.java).item)
+                    entity.itemStack ?: ItemStack.empty()
                 )
             }
         }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/culling/BlockCullingEngine.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/culling/BlockCullingEngine.kt
@@ -40,6 +40,7 @@ import org.bukkit.event.world.WorldLoadEvent
 import org.bukkit.event.world.WorldUnloadEvent
 import org.bukkit.util.BoundingBox
 import org.bukkit.util.Vector
+import org.jetbrains.annotations.ApiStatus
 import java.lang.invoke.MethodHandles
 import java.time.Duration
 import java.util.UUID
@@ -61,8 +62,9 @@ object BlockCullingEngine : Listener {
 
     internal val occludingCache = mutableMapOf<UUID, MutableMap<Long, ChunkData>>()
 
-    internal val blockTextureOctrees = mutableMapOf<UUID, Octree<RebarBlock>>()
-    internal  val culledBlockOctrees = mutableMapOf<UUID, Octree<RebarBlock>>()
+    @get:ApiStatus.Internal
+    val blockTextureOctrees = mutableMapOf<UUID, Octree<RebarBlock>>()
+    internal val culledBlockOctrees = mutableMapOf<UUID, Octree<RebarBlock>>()
 
     private val jobs = mutableMapOf<UUID, Job>()
     internal val syncJobTasks = ConcurrentHashMap<UUID, MutableMap<RebarCulledBlock, Boolean>>()

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/culling/BlockCullingEngine.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/culling/BlockCullingEngine.kt
@@ -62,7 +62,7 @@ object BlockCullingEngine : Listener {
 
     internal val occludingCache = mutableMapOf<UUID, MutableMap<Long, ChunkData>>()
 
-    @get:ApiStatus.Internal
+    @JvmSynthetic @ApiStatus.Internal
     val blockTextureOctrees = mutableMapOf<UUID, Octree<RebarBlock>>()
     internal val culledBlockOctrees = mutableMapOf<UUID, Octree<RebarBlock>>()
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/packet/BlockTextureEntity.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/packet/BlockTextureEntity.kt
@@ -1,159 +1,52 @@
 package io.github.pylonmc.rebar.entity.packet
 
-import com.github.retrooper.packetevents.PacketEvents
-import com.github.retrooper.packetevents.protocol.entity.data.EntityData
-import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes
-import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes
-import com.github.retrooper.packetevents.protocol.item.ItemStack
-import com.github.retrooper.packetevents.util.Vector3f
-import com.github.retrooper.packetevents.wrapper.PacketWrapper
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata
 import io.github.pylonmc.rebar.block.RebarBlock
-import io.github.pylonmc.rebar.nms.NmsAccessor
-import io.github.pylonmc.rebar.culling.BlockCullingEngine
-import io.github.retrooper.packetevents.util.SpigotConversionUtil
-import me.tofaa.entitylib.wrapper.WrapperEntity
-import java.util.*
-import kotlin.math.abs
-import kotlin.math.min
+import org.bukkit.Color
+import org.bukkit.entity.Display
+import org.bukkit.entity.ItemDisplay
+import org.bukkit.inventory.ItemStack
+import org.bukkit.util.Transformation
+import org.joml.Matrix4f
+import java.util.UUID
 
-/**
- * A specific [WrapperEntity] for [RebarBlock] textures. It is an item display entity
- * that will scale based on the distance to the viewer to prevent z-fighting with the
- * block overlaid upon.
- * 
- * (see [RebarBlock.blockTextureEntity] and [BlockCullingEngine])
- */
-open class BlockTextureEntity(
+interface BlockTextureEntity {
     val block: RebarBlock
-) : WrapperEntity(EntityTypes.ITEM_DISPLAY) {
+    var id: Int
+    var uuid: UUID
+    val viewers: Set<UUID>
 
-    private val lastScaleIncreases = mutableMapOf<UUID, Float>()
+    val isSpawned: Boolean
 
-    /**
-     * The translation needed to center scaling on the bounding box center instead of the block center.
-     * This is needed so that the scaling of non-full blocks (like slabs) scales around the correct point.
-     * The bounding box is unlikely to change often, so we cache the translation and only recalculate it every 5 seconds when requested.
-     */
-    private var scaleTranslation = calculateScaleTranslation()
-        get() {
-            if (System.currentTimeMillis() - translationTimestamp > 5000) {
-                field = calculateScaleTranslation()
-                translationTimestamp = System.currentTimeMillis()
-            }
-            return field
-        }
-    private var translationTimestamp = System.currentTimeMillis()
+    var transformation: Transformation
+    var transformationMatrix: Matrix4f
 
-    open fun addOrRefreshViewer(viewer: UUID, distanceSquared: Double) {
-        if (this.viewers.add(viewer)) {
-            if (location != null && isSpawned) {
-                sendPacketToViewer(viewer, this.createSpawnPacket(), distanceSquared)
-                sendPacketToViewer(viewer, this.entityMeta.createPacket(), distanceSquared)
-            }
-        } else if (location != null && isSpawned) {
-            refreshViewer(viewer, distanceSquared)
-        }
-    }
+    var interpolationDelay: Int
+    var interpolationDuration: Int
+    var teleportDuration: Int
 
-    open fun refreshViewer(viewer: UUID, distanceSquared: Double) {
-        val scale = entityMeta.getIndex(SCALE_INDEX.toByte(), null as Vector3f?) ?: DEFAULT_SCALE
-        val translation = entityMeta.getIndex(TRANSLATION_INDEX.toByte(), null as Vector3f?) ?: DEFAULT_TRANSLATION
-        val metadata = arrayListOf(
-            EntityData(TRANSLATION_INDEX, EntityDataTypes.VECTOR3F, translation),
-            EntityData(SCALE_INDEX, EntityDataTypes.VECTOR3F, scale)
-        ) as List<EntityData<*>>
-        sendPacketToViewer(viewer, WrapperPlayServerEntityMetadata(entityId, metadata), distanceSquared, true)
-    }
+    var shadowRadius: Float
+    var shadowStrength: Float
 
-    open fun sendPacketToViewer(viewer: UUID, wrapper: PacketWrapper<*>, distanceSquared: Double, refresh: Boolean = false) {
-        if (wrapper is WrapperPlayServerEntityMetadata) {
-            if (!refresh) {
-                val playerTranslator = NmsAccessor.instance.getTranslationHandler(viewer)
-                if (playerTranslator != null) {
-                    wrapper.entityMetadata = ArrayList(wrapper.entityMetadata)
-                    for (i in wrapper.entityMetadata.indices) {
-                        val value = wrapper.entityMetadata[i].value
-                        if (value is ItemStack) {
-                            val bukkitStack = SpigotConversionUtil.toBukkitItemStack(value)
-                            playerTranslator.handleItem(bukkitStack)
-                            wrapper.entityMetadata[i] = EntityData<ItemStack>(
-                                wrapper.entityMetadata[i].index,
-                                EntityDataTypes.ITEMSTACK,
-                                SpigotConversionUtil.fromBukkitItemStack(bukkitStack)
-                            )
-                        } else if (value is Optional<*> && value.isPresent && value.get() is ItemStack) {
-                            val bukkitStack = SpigotConversionUtil.toBukkitItemStack(value.get() as ItemStack)
-                            playerTranslator.handleItem(bukkitStack)
-                            wrapper.entityMetadata[i] = EntityData<Optional<ItemStack>>(
-                                wrapper.entityMetadata[i].index,
-                                EntityDataTypes.OPTIONAL_ITEMSTACK,
-                                Optional.of(SpigotConversionUtil.fromBukkitItemStack(bukkitStack))
-                            )
-                        }
-                    }
-                }
-            } else {
-                val scaleIncrease = min((distanceSquared * SCALE_DISTANCE_INCREASE).toFloat(), MAX_SCALE_INCREASE)
-                val lastScaleIncrease = lastScaleIncreases[viewer] ?: 0f
-                if (abs(scaleIncrease - lastScaleIncrease) < SCALE_DISTANCE_THRESHOLD && wrapper.entityMetadata.size == 2) {
-                    return
-                }
+    var displayWidth: Float
+    var displayHeight: Float
+    var viewRange: Float
 
-                lastScaleIncreases[viewer] = scaleIncrease
+    var glowColorOverride: Color?
+    var billboard: Display.Billboard
+    var brightness: Display.Brightness?
 
-                @Suppress("UNCHECKED_CAST")
-                val scaleData = wrapper.entityMetadata.find { it.index == SCALE_INDEX && it.type == EntityDataTypes.VECTOR3F } as? EntityData<Vector3f> ?: return
-                val scale = (scaleData.value as Vector3f).add(scaleIncrease, scaleIncrease, scaleIncrease)
-                scaleData.value = scale
+    var itemStack: ItemStack?
+    var itemDisplayTransform: ItemDisplay.ItemDisplayTransform
 
-                @Suppress("UNCHECKED_CAST")
-                val translationData = wrapper.entityMetadata.find { it.index == TRANSLATION_INDEX && it.type == EntityDataTypes.VECTOR3F } as? EntityData<Vector3f> ?: return
-                val translation = Vector3f(scaleTranslation.x * (1 - scale.x), scaleTranslation.y * (1 - scale.y), scaleTranslation.z * (1 - scale.z))
-                translationData.value = translation
-            }
-        }
+    fun addOrRefreshViewer(playerId: UUID, distanceSquared: Double)
+    fun refreshViewer(playerId: UUID, distanceSquared: Double)
+    fun hasViewer(playerId: UUID): Boolean
+    fun removeViewer(playerId: UUID)
+    fun removeAllViewers()
 
-        val protocolManager = PacketEvents.getAPI().protocolManager ?: return
-        val channel = protocolManager.getChannel(viewer) ?: return
-        protocolManager.sendPacket(channel, wrapper)
-    }
-
-    override fun removeViewer(uuid: UUID) {
-        super.removeViewer(uuid)
-        lastScaleIncreases.remove(uuid)
-    }
-
-    open fun removeAllViewers() {
-        for (viewer in viewers.toSet()) {
-            removeViewer(viewer)
-        }
-    }
-
-    private fun calculateScaleTranslation(): Vector3f {
-        val boundingBox = block.block.boundingBox
-        val blockX = block.block.x
-        val blockY = block.block.y
-        val blockZ = block.block.z
-
-        val bbCenterX = (boundingBox.minX + boundingBox.maxX) / 2.0 - blockX
-        val bbCenterY = (boundingBox.minY + boundingBox.maxY) / 2.0 - blockY
-        val bbCenterZ = (boundingBox.minZ + boundingBox.maxZ) / 2.0 - blockZ
-
-        return Vector3f(
-            (bbCenterX - 0.5).toFloat(),
-            (bbCenterY - 0.5).toFloat(),
-            (bbCenterZ - 0.5).toFloat()
-        )
-    }
+    fun spawn()
 
     companion object {
-        const val SCALE_INDEX = 12
-        const val TRANSLATION_INDEX = 11
-
-        val DEFAULT_SCALE = Vector3f(1f, 1f, 1f)
-        val DEFAULT_TRANSLATION = Vector3f(0f, 0f, 0f)
-
         /**
          * A base scale to prevent z-fighting between the block and item display when the player is right next to a block.
          */
@@ -174,7 +67,8 @@ open class BlockTextureEntity(
         /**
          * Calculate scale increase so that at EXPECTED_REACH_DISTANCE, the scale increase is double BLOCK_OVERLAP_SCALE
          */
-        const val SCALE_DISTANCE_INCREASE = BLOCK_OVERLAP_INCREASE / (DOUBLE_OVERLAP_INCREASE_DISTANCE * DOUBLE_OVERLAP_INCREASE_DISTANCE)
+        const val SCALE_DISTANCE_INCREASE =
+            BLOCK_OVERLAP_INCREASE / (DOUBLE_OVERLAP_INCREASE_DISTANCE * DOUBLE_OVERLAP_INCREASE_DISTANCE)
 
         /**
          * If the difference between the new scale increase and the last scale increase sent to the viewer is less than 1/10th of the base BLOCK_OVERLAP_SCALE, we don't send a packet to avoid unnecessary packet spam.

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessor.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessor.kt
@@ -1,6 +1,8 @@
 package io.github.pylonmc.rebar.nms
 
 import com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent
+import io.github.pylonmc.rebar.block.RebarBlock
+import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity
 import io.github.pylonmc.rebar.i18n.PlayerTranslationHandler
 import net.kyori.adventure.text.Component
 import org.bukkit.Material
@@ -47,6 +49,8 @@ interface NmsAccessor {
     fun handleRecipeBookClick(event: PlayerRecipeBookClickEvent)
 
     fun hasTracker(entity: Entity): Boolean
+
+    fun createBlockTextureEntity(block: RebarBlock): BlockTextureEntity
 
     companion object {
         val instance = Class.forName("io.github.pylonmc.rebar.nms.NmsAccessorImpl")

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/util/Octree.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/util/Octree.kt
@@ -148,8 +148,8 @@ open class Octree<N>(
         return children?.maxOfOrNull { it.maxDepth() } ?: depth
     }
 
-    fun allEntries(): Set<N> {
-        val result = mutableSetOf<N>()
+    fun allEntries(): MutableList<N> {
+        val result = mutableListOf<N>()
         result.addAll(entries)
         if (storeOutOfBoundsEntries) result.addAll(outOfBoundsEntries)
         children?.forEach { result.addAll(it.allEntries()) }


### PR DESCRIPTION
(relies on #736 as it removes the other packet events usage)

Removes the dependency on EntityLib & PacketEvents ( fixes #689 ) in favor of a custom packet entity implementation using NMS
Now that its custom: 
- its more flexible
- we can fix anything without having to rely on the external plugins
- the front end API is in normal bukkit classes so its MUCH more user friendly
- now that its an interface people can create their own implementations for even *more* flexibility