### PR TITLE
fix: publishing issues

### DIFF
--- a/dokka-plugin/build.gradle.kts
+++ b/dokka-plugin/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-    compileOnly("org.jetbrains.dokka:dokka-core:2.0.0")
-    implementation("org.jetbrains.dokka:dokka-base:2.0.0")
+    compileOnly("org.jetbrains.dokka:dokka-core:2.2.0")
+    implementation("org.jetbrains.dokka:dokka-base:2.2.0")
 }
 
 tasks.test {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
         gradlePluginPortal()
     }
 
-    val dokkaVersion = if (useLocalDokka) "2.1.0-rebar-SNAPSHOT" else "2.0.0"
+    val dokkaVersion = if (useLocalDokka) "2.1.0-rebar-SNAPSHOT" else "2.2.0"
     plugins {
         id("org.jetbrains.dokka") version dokkaVersion
         id("org.jetbrains.dokka-javadoc") version dokkaVersion


### PR DESCRIPTION
Dokka supports Java 25 on 2.1.0+. Upgrading dokka to 2.2.0 solved the publishing issue.

Tested with `./gradlew clean :rebar:publishToMavenLocal`

This does not solve KDocs publishing.