### PR TITLE
fix(nms): handle new slot display types

### DIFF
--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/i18n/packet/PlayerPacketHandler.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/i18n/packet/PlayerPacketHandler.kt
@@ -225,6 +225,20 @@ class PlayerPacketHandler(private val player: ServerPlayer, val handler: PlayerT
                 handleSlotDisplay(display.remainder)
             )
 
+            is SlotDisplay.OnlyWithComponent -> SlotDisplay.OnlyWithComponent(
+                handleSlotDisplay(display.source),
+                display.component
+            )
+
+            is SlotDisplay.WithAnyPotion -> SlotDisplay.WithAnyPotion(
+                handleSlotDisplay(display.display)
+            )
+
+            is SlotDisplay.DyedSlotDemo -> SlotDisplay.DyedSlotDemo(
+                handleSlotDisplay(display.dye),
+                handleSlotDisplay(display.target)
+            )
+
             else -> throw IllegalArgumentException("Unknown slot display type: ${display::class.simpleName}")
         }
     }


### PR DESCRIPTION
When using `/recipe give username *`, the target player disconnects with the following reason and cannot connect to server unless world is reset.

`Internal Exception: java.lang.IllegalArgumentException: Unknown slot display type: OnlyWithComponent`

This PR handles the 3 new SlotDisplay types added in 26.1.

Reference:
- https://javadocs.packetevents.com/com/github/retrooper/packetevents/protocol/recipe/display/slot/OnlyWithComponentSlotDisplay.html                   
- https://javadocs.packetevents.com/com/github/retrooper/packetevents/protocol/recipe/display/slot/WithAnyPotionSlotDisplay.html                       
- https://javadocs.packetevents.com/com/github/retrooper/packetevents/protocol/recipe/display/slot/DyedSlotDisplay.html    