### PR TITLE
Feature/alternate guide search

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/fluid/RebarFluid.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/fluid/RebarFluid.kt
@@ -31,6 +31,8 @@ open class RebarFluid(
     private val tags: MutableList<RebarFluidTag>,
 ) : Keyed {
 
+    val addon = getAddon(key)
+
     private val internalItem by lazy {
         val builder = ItemStackBuilder.of(material)
             .editPdc { it.set(rebarFluidKeyKey, RebarSerializers.NAMESPACED_KEY, key) }
@@ -40,8 +42,6 @@ open class RebarFluid(
         for (tag in tags) {
             builder.lore(tag.displayText)
         }
-
-        builder.lore(getAddon(key).footerName)
 
         builder.build()
     }
@@ -58,7 +58,6 @@ open class RebarFluid(
 
     init {
         if (key !in nameWarningsSuppressed) {
-            val addon = RebarRegistry.ADDONS[NamespacedKey(key.namespace, key.namespace)]!!
             for (locale in addon.languages) {
                 val translationKey = "${key.namespace}.fluid.${key.key}"
                 if (!addon.translator.canTranslate(translationKey, locale)) {

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/base/SearchPage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/base/SearchPage.kt
@@ -1,9 +1,7 @@
 package io.github.pylonmc.rebar.guide.pages.base
 
-import info.debatty.java.stringsimilarity.JaroWinkler
 import io.github.pylonmc.rebar.content.guide.RebarGuide
-import io.github.pylonmc.rebar.guide.button.FluidButton
-import io.github.pylonmc.rebar.item.RebarItem
+import io.github.pylonmc.rebar.fluid.RebarFluid
 import io.github.pylonmc.rebar.item.RebarItemSchema
 import io.github.pylonmc.rebar.item.builder.ItemStackBuilder
 import io.github.pylonmc.rebar.registry.RebarRegistry
@@ -86,58 +84,35 @@ abstract class SearchPage(key: NamespacedKey) : SimpleStaticGuidePage(key) {
     open fun getItems(player: Player, search: String): List<Item> {
         if (search.isBlank()) {
             return getItemNamePairs(player, search)
-                .sortedBy { it.second }
                 .map { it.first }
         }
 
-        val specifiers = mutableListOf<SearchSpecifier>()
         val split = search.split(" ")
-
-        // Because name specifiers can contain spaces, we need to accumulate them until we hit a different specifier
-        val nameSearch = StringBuilder()
-        fun buildNameSearch() {
-            if (!nameSearch.isEmpty()) {
-                specifiers.add(SearchSpecifier.ItemName(nameSearch.toString()))
-            }
-        }
+        val entries = getItemNamePairs(player, search).toMutableList()
 
         for (piece in split) {
-            if (piece.isEmpty()) continue
-            val type = piece[0]
-            when(type) {
-                '@' -> {
-                    buildNameSearch()
-                    specifiers.add(SearchSpecifier.Namespace(piece.substring(1)))
+            if (piece.isEmpty() || (piece[0] == '@' || piece[0] == '$') && piece.length == 1) continue
+            val predicate = when(piece[0]) {
+                '@' -> { entry: Pair<Item, String> ->
+                    getDisplayNamespace(entry.first, player).contains(piece.substring(1), true)
                 }
-                '$' -> {
-                    buildNameSearch()
-                    specifiers.add(SearchSpecifier.Lore(piece.substring(1)))
+                '$' -> { entry: Pair<Item, String> ->
+                    entry.first.getItemProvider(player).get().lore()?.any { it.plainText.contains(piece.substring(1), true) } ?: false
                 }
-                else -> {
-                    if (nameSearch.isNotEmpty()) nameSearch.append(" ")
-                    nameSearch.append(piece)
+                else -> { entry: Pair<Item, String> ->
+                    entry.second.contains(piece, true)
                 }
             }
-        }
-        buildNameSearch()
-
-        val entries = getItemNamePairs(player, search).toMutableList()
-        for (specifier in specifiers) {
-            // Map each entry to its weight for this specifier, excluding non-matching entries
-            val weighted = entries.mapNotNull { entry ->
-                val weight = specifier.weight(player, entry) ?: return@mapNotNull null
-                Pair(entry.first, weight)
-            }
-            // Remove entries that didn't match this specifier (are not in the weighted list)
-            entries.removeIf { entry ->
-                weighted.none { it.first == entry.first }
-            }
-            // Sort remaining entries by their weight for this specifier
-            entries.sortBy { entry ->
-                weighted.first { it.first == entry.first }.second
-            }
+            entries.retainAll(predicate)
         }
         return entries.map { it.first }.toList()
+    }
+
+    fun getDisplayNamespace(item: Item, player: Player): String {
+        val itemStack = item.getItemProvider(player).get()
+        val key = RebarItemSchema.fromStack(itemStack)?.key ?: RebarFluid.fromStack(itemStack)?.key ?: itemStack.type.key
+        val addon = RebarRegistry.ADDONS[NamespacedKey(key.namespace, key.namespace)]
+        return addon?.let { GlobalTranslator.render(addon.footerName, player.locale()).plainText.lowercase() } ?: key.namespace
     }
 
     companion object {
@@ -145,51 +120,6 @@ abstract class SearchPage(key: NamespacedKey) : SimpleStaticGuidePage(key) {
             .name(Component.translatable("rebar.guide.button.search-specifiers.name"))
             .lore(Component.translatable("rebar.guide.button.search-specifiers.lore"))
 
-        private val searchAlgorithm = JaroWinkler()
         private val searches = mutableMapOf<UUID, String>()
-
-        private fun weight(search: String, text: String): Double? {
-            val distance = searchAlgorithm.distance(text, search)
-            val weight = when {
-                text == search -> 0.0
-                text.startsWith(search) -> 1.0 + distance
-                text.contains(search) -> 2.0 + distance
-                else -> 3.0 + distance
-            }
-            return weight.takeIf { weight < 3.15 }
-        }
-    }
-
-    private fun interface SearchSpecifier {
-        fun weight(player: Player, entry: Pair<Item, String>): Double?
-
-        data class ItemName(val filter: String) : SearchSpecifier {
-            override fun weight(player: Player, entry: Pair<Item, String>): Double? {
-                return weight(filter, entry.second)
-            }
-        }
-
-        data class Namespace(val filter: String) : SearchSpecifier {
-            override fun weight(player: Player, entry: Pair<Item, String>): Double? {
-                val item = entry.first
-                val key: NamespacedKey = if (item is FluidButton) {
-                    item.currentFluid.key
-                } else {
-                    RebarItemSchema.fromStack(item.getItemProvider(player).get())?.key ?: return null
-                }
-                val addon = RebarRegistry.ADDONS[NamespacedKey(key.namespace, key.namespace)] ?: return null
-                val compactName = GlobalTranslator.render(addon.displayName, player.locale()).plainText.replace(" ", "").lowercase(player.locale())
-                return if (key.namespace.startsWith(filter) || compactName.startsWith(filter)) 0.0 else null
-            }
-        }
-
-        data class Lore(val filter: String) : SearchSpecifier {
-            override fun weight(player: Player, entry: Pair<Item, String>): Double? {
-                val stack = entry.first.getItemProvider(player).get()
-                return stack.lore()?.map {
-                    weight(filter, it.plainText.lowercase(player.locale()))
-                }?.filterNotNull()?.minOrNull()
-            }
-        }
     }
 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/PlayerTranslationHandler.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/PlayerTranslationHandler.kt
@@ -3,6 +3,7 @@
 package io.github.pylonmc.rebar.i18n
 
 import io.github.pylonmc.rebar.datatypes.RebarSerializers
+import io.github.pylonmc.rebar.fluid.RebarFluid
 import io.github.pylonmc.rebar.i18n.RebarTranslator.Companion.translate
 import io.github.pylonmc.rebar.i18n.RebarTranslator.Companion.untranslate
 import io.github.pylonmc.rebar.item.RebarItem
@@ -23,18 +24,20 @@ import org.jetbrains.annotations.ApiStatus
 class PlayerTranslationHandler internal constructor(private val player: Player) {
     fun handleItem(stack: ItemStack) {
         val rebarItem = RebarItem.fromStack(stack)
+        val rebarFluid = RebarFluid.fromStack(stack)
         val placeholders = rebarItem?.getPlaceholders().orEmpty()
 
         stack.translate(player.locale(), placeholders)
 
-        if (rebarItem != null && !stack.persistentDataContainer.has(FOOTER_APPENDED)) {
+        if ((rebarItem != null || rebarFluid != null) && !stack.persistentDataContainer.has(FOOTER_APPENDED)) {
             stack.editData(DataComponentTypes.LORE) { lore ->
                 val newLore = lore.lines().toMutableList()
                 if (!stack.enchantments.isEmpty()) {
                     newLore.addFirst(Component.empty())
                 }
-                newLore.add(GlobalTranslator.render(rebarItem.addon.footerName, player.locale()))
-                if (rebarItem.isDisabled) {
+                val addon = rebarItem?.addon ?: rebarFluid?.addon!!
+                newLore.add(GlobalTranslator.render(addon.footerName, player.locale()))
+                if (rebarItem?.isDisabled ?: false) {
                     newLore.add(
                         GlobalTranslator.render(
                             Component.translatable("rebar.message.disabled.lore"),

--- a/rebar/src/main/resources/lang/en.yml
+++ b/rebar/src/main/resources/lang/en.yml
@@ -143,10 +143,11 @@ guide:
     search-specifiers:
       name: "Search Specifiers"
       lore: |-
-        <guidearrow> By default, searches through item names greedily ("iron ingot" searches for exactly "iron ingot" not "iron" and "ingot")
+        <guidearrow> By default, words will search in item names
         <guidearrow> Prefix <light_purple>@</light_purple> to search by <light_purple>addon</light_purple> id or display name (e.g. "pylon")
         <guidearrow> Prefix <aqua>$</aqua> to search in <aqua>lore</aqua>
         <guidearrow> Prefixed searches only apply to the word directly after the prefix
+        <guidearrow> Spaces are treated as 'and' ("iron ingot" searches for "iron" and "ingot")
         <guidearrow> Example: <light_purple>@pylon <white>iron <aqua>$temperature <white>slurry
     research:
       cost:


### PR DESCRIPTION
@ searches in translated namespace. space is treated as &&. Skip empty @ and $ specifiers. Removed JaroWrinkler and unnecessary abstraction. $pylon no longer finds all fluids.