### PR TITLE
Fix BlockTextureEntity Brightness

### DIFF
--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
@@ -42,6 +42,7 @@ import org.joml.Matrix4f
 import org.joml.Quaternionf
 import org.joml.Vector3f
 import java.util.*
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CopyOnWriteArraySet
 import kotlin.math.abs
 import kotlin.math.min
@@ -51,7 +52,9 @@ import net.minecraft.world.item.ItemStack as NmsItemStack
 
 class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
     override val block: RebarBlock
+    val neighborPositions: List<Long>
     override val lightDelegatePositions: List<Long>
+        get() = if (directLighting) emptyList() else neighborPositions
     override var id: Int
     override var uuid: UUID
     override val viewers: MutableSet<UUID> = mutableSetOf()
@@ -117,7 +120,7 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
 
     constructor(block: RebarBlock) {
         this.block = block
-        this.lightDelegatePositions = IMMEDIATE_FACES.map { BlockPosition.asLong(block.block.getRelative(it)) }
+        this.neighborPositions = IMMEDIATE_FACES.map { BlockPosition.asLong(block.block.getRelative(it)) }
         this.id = Bukkit.getUnsafe().nextEntityId()
         this.uuid = Mth.createInsecureUUID(Entity.SHARED_RANDOM)
         this.entityData = EntityDataAccess.fakedDataBuilder(this, NmsDisplay.ItemDisplay::class.java).apply {

--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
@@ -1,20 +1,20 @@
 package io.github.pylonmc.rebar.nms.entity
 
-import com.mojang.math.MatrixUtil
 import io.github.pylonmc.rebar.Rebar
 import io.github.pylonmc.rebar.block.RebarBlock
 import io.github.pylonmc.rebar.culling.BlockCullingEngine
 import io.github.pylonmc.rebar.entity.display.transform.TransformUtil.toMatrix
 import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity
+import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity.Companion.BLOCK_OVERLAP_INCREASE
 import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity.Companion.MAX_SCALE_INCREASE
 import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity.Companion.SCALE_DISTANCE_INCREASE
 import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity.Companion.SCALE_DISTANCE_THRESHOLD
+import io.github.pylonmc.rebar.util.IMMEDIATE_FACES
 import io.github.pylonmc.rebar.util.delayTicks
+import io.github.pylonmc.rebar.util.position.BlockPosition
 import kotlinx.coroutines.launch
 import net.minecraft.network.protocol.Packet
-import net.minecraft.network.protocol.game.ClientboundAddEntityPacket
-import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket
-import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket
+import net.minecraft.network.protocol.game.*
 import net.minecraft.network.syncher.EntityDataAccessor
 import net.minecraft.network.syncher.EntityDataSerializers
 import net.minecraft.network.syncher.SyncedDataHolder
@@ -24,11 +24,13 @@ import net.minecraft.util.Mth
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.EntityType
 import net.minecraft.world.entity.Pose
+import net.minecraft.world.entity.PositionMoveRotation
 import net.minecraft.world.item.ItemDisplayContext
 import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.phys.Vec3
 import org.bukkit.Bukkit
 import org.bukkit.Color
+import org.bukkit.block.BlockFace
 import org.bukkit.craftbukkit.block.CraftBlock
 import org.bukkit.craftbukkit.entity.CraftPlayer
 import org.bukkit.craftbukkit.inventory.CraftItemStack
@@ -36,19 +38,29 @@ import org.bukkit.entity.Display
 import org.bukkit.entity.ItemDisplay
 import org.bukkit.inventory.ItemStack
 import org.bukkit.util.Transformation
-import org.joml.*
+import org.joml.Matrix4f
+import org.joml.Quaternionf
+import org.joml.Vector3f
 import java.util.*
+import java.util.concurrent.CopyOnWriteArraySet
 import kotlin.math.abs
 import kotlin.math.min
+import com.mojang.math.Transformation as NmsTransformation
 import net.minecraft.world.entity.Display as NmsDisplay
 import net.minecraft.world.item.ItemStack as NmsItemStack
 
 class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
     override val block: RebarBlock
+    override val lightDelegatePositions: List<Long>
     override var id: Int
     override var uuid: UUID
     override val viewers: MutableSet<UUID> = mutableSetOf()
 
+    var refreshesFrozen: Boolean = false
+    var refreshesFrozenExpireTime: Long = 0
+
+    private val position: Vec3
+        get() = Vec3(block.block.x + 0.5 + lightingOffset.x, block.block.y + 0.5 + lightingOffset.y, block.block.z + 0.5 + lightingOffset.z)
     override var isSpawned: Boolean = false
 
     private val entityData: SynchedEntityData
@@ -56,32 +68,54 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
     /**
      * The data to sync on player refresh
      */
-    private val refreshDataValues: List<SynchedEntityData.DataValue<*>>
+    private val refreshData: List<SynchedEntityData.DataItem<*>>
 
     /**
-     * The data value for the item of the [BlockTextureEntity]
+     * The data to sync when lighting offset changes
      */
-    internal val itemUpdateDataValue: SynchedEntityData.DataItem<NmsItemStack>
+    private val lightingData: List<SynchedEntityData.DataItem<*>>
+
+    /**
+     * The data for the item of the [BlockTextureEntity]
+     */
+    internal val itemUpdateData: SynchedEntityData.DataItem<NmsItemStack>
 
     /**
      * The packet used to update only the item of the [BlockTextureEntity]
      */
     internal val itemUpdatePacket: ClientboundSetEntityDataPacket
-        get() = ClientboundSetEntityDataPacket(id, listOf(itemUpdateDataValue.value()))
+        get() = ClientboundSetEntityDataPacket(id, listOf(itemUpdateData.value()))
 
-    private val lastScaleIncreases: MutableMap<UUID, Float> = mutableMapOf()
+    /**
+     * If the brightness has been overridden externally or the block state already has lighting data,
+     * then we don't need to delegate to a neighboring block to get lighting data
+     */
+    private val directLighting: Boolean
+        get() = brightness != null || lastState.hasLightingData
+
+    /**
+     * The offset needed to put the entity in a location that has lighting data
+     * This is needed so that occluding blocks don't cause the entity to be rendered at 0 brightness
+     */
+    private var lightingOffset: Vector3f = ZERO_VECTOR
 
     /**
      * The transformation of the texture entity needs to be centered on the bounding box of the block instead of the block center.
      * This is needed so that the scaling of non-full blocks (like slabs) scales around the correct point to combat z-fighting.
      */
-    private var centerTranslation: Vector3f
+    private var centerOffset: Vector3f
 
     var lastState: BlockState
     var stateWasUpdated: Boolean = false
 
+    /**
+     * A map of the last scale increase sent to each player, used to prevent sending unnecessary scale updates when the player is far enough away that the scale increase doesn't change anymore or when the change is by to small a margin
+     */
+    private val lastScaleIncreases: MutableMap<UUID, Float> = mutableMapOf()
+
     constructor(block: RebarBlock) {
         this.block = block
+        this.lightDelegatePositions = IMMEDIATE_FACES.map { BlockPosition.asLong(block.block.getRelative(it)) }
         this.id = Bukkit.getUnsafe().nextEntityId()
         this.uuid = Mth.createInsecureUUID(Entity.SHARED_RANDOM)
         this.entityData = EntityDataAccess.fakedDataBuilder(this, NmsDisplay.ItemDisplay::class.java).apply {
@@ -98,10 +132,10 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
             define(EntityDataAccess.DISPLAY_DATA_POS_ROT_INTERPOLATION_DURATION_ID, 0)
             define(EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID, 0)
             define(EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID, 0)
-            define(EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID, Vector3f())
+            define(EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID, ZERO_VECTOR)
             define(EntityDataAccess.DISPLAY_DATA_SCALE_ID, Vector3f(1.0F, 1.0F, 1.0F))
-            define(EntityDataAccess.DISPLAY_DATA_RIGHT_ROTATION_ID, Quaternionf())
-            define(EntityDataAccess.DISPLAY_DATA_LEFT_ROTATION_ID, Quaternionf())
+            define(EntityDataAccess.DISPLAY_DATA_RIGHT_ROTATION_ID, ZERO_QUATERNION)
+            define(EntityDataAccess.DISPLAY_DATA_LEFT_ROTATION_ID, ZERO_QUATERNION)
             define(EntityDataAccess.DISPLAY_DATA_BILLBOARD_RENDER_CONSTRAINTS_ID, 0.toByte())
             define(EntityDataAccess.DISPLAY_DATA_BRIGHTNESS_OVERRIDE_ID, -1)
             define(EntityDataAccess.DISPLAY_DATA_VIEW_RANGE_ID, 1.0F)
@@ -114,45 +148,27 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
             define(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_STACK_ID, NmsItemStack.EMPTY)
             define(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_DISPLAY_ID, ItemDisplayContext.NONE.id)
         }.build()
-        this.refreshDataValues = entityData.packAll().filter { it.id == EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID.id || it.id == EntityDataAccess.DISPLAY_DATA_LEFT_ROTATION_ID.id || it.id == EntityDataAccess.DISPLAY_DATA_SCALE_ID.id || it.id == EntityDataAccess.DISPLAY_DATA_RIGHT_ROTATION_ID.id  }
-        this.itemUpdateDataValue = entityData.getItem(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_STACK_ID)
+        this.entityData.set(EntityDataAccess.DISPLAY_DATA_SCALE_ID, Vector3f(1.0F + BLOCK_OVERLAP_INCREASE))
+        this.entityData.set(EntityDataAccess.DISPLAY_DATA_POS_ROT_INTERPOLATION_DURATION_ID, 1)
+
+        this.refreshData = REFRESH_IDS.map { entityData.getItem(it) }
+        this.lightingData = REFRESH_IDS.map { entityData.getItem(it) } + INTERPOLATION_IDS.map { entityData.getItem(it) }
+        this.itemUpdateData = entityData.getItem(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_STACK_ID)
         this.lastState = (block.block as CraftBlock).blockState
-        this.centerTranslation = calculateCenterTranslation()
+        this.lightingOffset = calculateLightingOffset()
+        this.centerOffset = calculateCenterOffset()
+        updateLighting()
     }
 
-    override var transformation: Transformation
+    val transformation: Transformation
         get() = Transformation(
             Vector3f(entityData.get(EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID)),
-            Quaternionf(entityData.get(EntityDataAccess.DISPLAY_DATA_LEFT_ROTATION_ID)),
+            ZERO_QUATERNION,
             Vector3f(entityData.get(EntityDataAccess.DISPLAY_DATA_SCALE_ID)),
-            Quaternionf(entityData.get(EntityDataAccess.DISPLAY_DATA_RIGHT_ROTATION_ID))
+            ZERO_QUATERNION
         )
-        set(value) {
-            entityData.set(EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID, value.translation)
-            entityData.set(EntityDataAccess.DISPLAY_DATA_LEFT_ROTATION_ID, value.leftRotation)
-            entityData.set(EntityDataAccess.DISPLAY_DATA_SCALE_ID, value.scale)
-            entityData.set(EntityDataAccess.DISPLAY_DATA_RIGHT_ROTATION_ID, value.rightRotation)
-        }
-    override var transformationMatrix: Matrix4f
+    val transformationMatrix: Matrix4f
         get() = transformation.toMatrix()
-        set(value) {
-            val f = 1.0F / value.m33();
-            val decomposed = MatrixUtil.svdDecompose(Matrix3f(value).scale(f))
-            entityData.set(EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID, value.getTranslation(Vector3f()).mul(f))
-            entityData.set(EntityDataAccess.DISPLAY_DATA_LEFT_ROTATION_ID, Quaternionf(decomposed.left))
-            entityData.set(EntityDataAccess.DISPLAY_DATA_SCALE_ID, Vector3f(decomposed.middle))
-            entityData.set(EntityDataAccess.DISPLAY_DATA_RIGHT_ROTATION_ID, Quaternionf(decomposed.right))
-        }
-
-    override var interpolationDelay: Int
-        get() = entityData.get(EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID)
-        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID, value)
-    override var interpolationDuration: Int
-        get() = entityData.get(EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID)
-        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID, value)
-    override var teleportDuration: Int
-        get() = entityData.get(EntityDataAccess.DISPLAY_DATA_POS_ROT_INTERPOLATION_DURATION_ID)
-        set(value) = entityData.set(EntityDataAccess.DISPLAY_DATA_POS_ROT_INTERPOLATION_DURATION_ID, value)
 
     override var shadowRadius: Float
         get() = entityData.get(EntityDataAccess.DISPLAY_DATA_SHADOW_RADIUS_ID)
@@ -194,24 +210,13 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
         get() = ItemDisplay.ItemDisplayTransform.entries[entityData.get(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_DISPLAY_ID).toInt()]
         set(value) = entityData.set(EntityDataAccess.ITEM_DISPLAY_DATA_ITEM_DISPLAY_ID, value.ordinal.toByte())
 
-    private fun calculateCenterTranslation(): Vector3f {
-        val block = (this.block.block as CraftBlock)
-        val shape = lastState.getShape(block.level, block.position)
-        if (shape.isEmpty) return ZERO_VECTOR
-
-        val center = shape.bounds().center
-        return Vector3f(
-            (center.x - 0.5).toFloat(),
-            (center.y - 0.5).toFloat(),
-            (center.z - 0.5).toFloat()
-        )
-    }
-
     override fun onSyncedDataUpdated(p0: EntityDataAccessor<*>) {}
     override fun onSyncedDataUpdated(p0: List<SynchedEntityData.DataValue<*>>) {}
 
-    private fun createDataPacket(playerId: UUID, distanceSquared: Double, trackedData: List<SynchedEntityData.DataValue<*>>, optional: Boolean) : ClientboundSetEntityDataPacket? {
-        var trackedData = trackedData
+    private fun createDataPacket(playerId: UUID, distanceSquared: Double, trackedData: List<SynchedEntityData.DataItem<*>>, optional: Boolean, forceTickDelay: Boolean = false)
+        = createDataPacketRaw(playerId, distanceSquared, trackedData.map { it.value() }, optional, forceTickDelay)
+
+    private fun createDataPacketRaw(playerId: UUID, distanceSquared: Double, trackedData: List<SynchedEntityData.DataValue<*>>, optional: Boolean, forceTickDelay: Boolean = false) : ClientboundSetEntityDataPacket? {
         val scaleIncrease = min((distanceSquared * SCALE_DISTANCE_INCREASE).toFloat(), MAX_SCALE_INCREASE)
         val lastScaleIncrease = lastScaleIncreases[playerId] ?: 0f
         if (abs(scaleIncrease - lastScaleIncrease) < SCALE_DISTANCE_THRESHOLD && optional) {
@@ -219,40 +224,42 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
         }
 
         lastScaleIncreases[playerId] = scaleIncrease
-        var scale: Vector3f? = null
-        trackedData = trackedData.map { data ->
-            if (data.id == EntityDataAccess.DISPLAY_DATA_SCALE_ID.id) {
-                scale = Vector3f(scaleIncrease).add(data.value as Vector3fc)
-                SynchedEntityData.DataValue(data.id, EntityDataSerializers.VECTOR3, scale)
-            } else {
-                data
-            }
-        }
+
+        val matrix = transformationMatrix
+            .scaleLocal(1 + scaleIncrease)
+            .translateLocal(centerOffset.mul(scaleIncrease, Vector3f()).negate())
+            .translateLocal(lightingOffset.negate(Vector3f()))
+        val transformation = NmsTransformation(matrix)
 
         return ClientboundSetEntityDataPacket(id, trackedData.map { data ->
-            if (data.id == EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID.id && scale != null) {
-                SynchedEntityData.DataValue(data.id, EntityDataSerializers.VECTOR3, Vector3f(
-                    centerTranslation.x * (1 - scale.x),
-                    centerTranslation.y * (1 - scale.y),
-                    centerTranslation.z * (1 - scale.z)
-                ))
-            } else {
-                data
+            when(data.id) {
+                EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID.id -> SynchedEntityData.DataValue(data.id, EntityDataSerializers.VECTOR3, transformation.translation())
+                EntityDataAccess.DISPLAY_DATA_SCALE_ID.id -> SynchedEntityData.DataValue(data.id, EntityDataSerializers.VECTOR3, transformation.scale())
+                EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID.id -> if (forceTickDelay) SynchedEntityData.DataValue(data.id, EntityDataSerializers.INT, 1) else data
+                EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID.id -> if (forceTickDelay) SynchedEntityData.DataValue(data.id, EntityDataSerializers.INT, 0) else data
+                else -> data
             }
         })
     }
 
     private fun sendPacket(playerId: UUID, packet: Packet<*>) {
-        val player = (Bukkit.getPlayer(playerId) as CraftPlayer).handle
+        val player = (Bukkit.getPlayer(playerId) as? CraftPlayer)?.handle ?: return
         player.connection.send(packet)
     }
 
     private fun addViewer(playerId: UUID, distanceSquared: Double) {
         sendPacket(playerId, ClientboundAddEntityPacket(
-            id, uuid, block.block.x + 0.5, block.block.y + 0.5, block.block.z + 0.5, 0f, 0f,
+            id, uuid, position.x, position.y, position.z, 0f, 0f,
             EntityType.ITEM_DISPLAY, 0, Vec3(0.0, 0.0, 0.0), 0.0
         ))
-        sendPacket(playerId, createDataPacket(playerId, distanceSquared, entityData.nonDefaultValues ?: listOf(), false) ?: return)
+
+        val dataValues = entityData.nonDefaultValues ?: mutableListOf()
+        refreshData.forEach { item ->
+            if (dataValues.none { it.id == item.accessor.id }) {
+                dataValues.add(item.value())
+            }
+        }
+        sendPacket(playerId, createDataPacketRaw(playerId, distanceSquared, dataValues, false) ?: return)
     }
 
     override fun addOrRefreshViewer(playerId: UUID, distanceSquared: Double) {
@@ -264,15 +271,19 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
     }
 
     override fun refreshViewer(playerId: UUID, distanceSquared: Double) {
-        sendPacket(playerId, createDataPacket(playerId, distanceSquared, refreshDataValues, true) ?: return)
+        if (refreshesFrozen) return
+        val packet = createDataPacket(playerId, distanceSquared, refreshData, true) ?: return
+        sendPacket(playerId, packet)
     }
 
     override fun hasViewer(playerId: UUID) = playerId in this.viewers
 
-    override fun removeViewer(playerId: UUID) {
+    override fun removeViewer(playerId: UUID): Boolean {
         if (this.viewers.remove(playerId)) {
             sendPacket(playerId, ClientboundRemoveEntitiesPacket(id))
+            return true
         }
+        return false
     }
 
     override fun removeAllViewers() {
@@ -289,6 +300,41 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
         }
     }
 
+    fun updateLighting(): Boolean {
+        val originalDelegates = this.lightDelegatePositions
+        val originalOffset = this.lightingOffset
+        this.lightingOffset = calculateLightingOffset()
+        if (this.lightingOffset === originalOffset) {
+            return false
+        }
+        this.centerOffset = calculateCenterOffset()
+
+        // prevent refreshes for 1 second to avoid refreshing while the client is updating the position & transformation
+        this.refreshesFrozen = true
+        this.refreshesFrozenExpireTime = System.currentTimeMillis() + 1000L
+
+        val positionPacket = ClientboundEntityPositionSyncPacket(id, PositionMoveRotation(this.position, ZERO_VEC, 0.0F, 0.0F), false)
+        for (viewer in viewers.toSet()) {
+            sendPacket(viewer, ClientboundBundlePacket(mutableListOf<Packet<in ClientGamePacketListener>>(
+                positionPacket,
+                createDataPacket(viewer, distanceSquared(this, viewer), lightingData, false, true)!!
+            )))
+
+            val job = BlockCullingEngine.getCullingJob(viewer) ?: continue
+            originalDelegates.forEach {
+                val delegates = job.lightDelegates[it] ?: return@forEach
+                delegates.remove(block)
+                if (delegates.isEmpty()) job.lightDelegates.remove(it)
+            }
+
+            lightDelegatePositions.forEach {
+                job.lightDelegates.getOrPut(it) { CopyOnWriteArraySet() }.add(block)
+            }
+        }
+
+        return true
+    }
+
     fun tryUpdateState(): Boolean {
         if (!stateWasUpdated) {
             val newState = (block.block as CraftBlock).blockState
@@ -296,17 +342,75 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
             lastState = newState
 
             block.refreshBlockTextureItem()
-            stateWasUpdated = itemUpdateDataValue.isDirty
+            stateWasUpdated = updateLighting() || itemUpdateData.isDirty
             if (stateWasUpdated) {
-                centerTranslation = calculateCenterTranslation()
+                centerOffset = calculateCenterOffset()
             }
         }
         return stateWasUpdated
     }
 
+    private fun calculateLightingOffset(): Vector3f {
+        if (directLighting) {
+            return ZERO_VECTOR
+        }
+
+        // Check for the first direct neighboring block that has lighting data with the highest light
+        var brightestFace: BlockFace? = null
+        var brightest = lightingOffset
+        var brightestLight = 0.toByte()
+        if (lightingOffset !== ZERO_VECTOR) {
+            val delegateBlock = block.block.getRelative(lightingOffset.x.toInt(), lightingOffset.y.toInt(), lightingOffset.z.toInt()) as? CraftBlock
+            if (delegateBlock?.blockState?.hasLightingData ?: false) {
+                brightestLight = delegateBlock.lightLevel
+                brightestFace = IMMEDIATE_FACES.firstOrNull { it.modX == lightingOffset.x.toInt() && it.modY == lightingOffset.y.toInt() && it.modZ == lightingOffset.z.toInt() }
+            }
+        }
+
+
+        for (face in IMMEDIATE_FACES) {
+            if (brightestFace == face) continue
+            val delegateBlock = block.block.getRelative(face) as? CraftBlock ?: continue
+            if (delegateBlock.blockState.hasLightingData) {
+                val light = delegateBlock.lightLevel
+                if (light > brightestLight) {
+                    brightestLight = light
+                    brightest = Vector3f(face.modX.toFloat(), face.modY.toFloat(), face.modZ.toFloat())
+                }
+            }
+        }
+        // If none of them do then the block won't be visible anyway.
+        return brightest
+    }
+
+    private fun calculateCenterOffset(): Vector3f {
+        val block = (this.block.block as CraftBlock)
+        val shape = this.lastState.getShape(block.level, block.position)
+        if (shape.isEmpty) return ZERO_VECTOR
+
+        val center = shape.bounds().center
+        return Vector3f(
+            (center.x - 0.5).toFloat(),
+            (center.y - 0.5).toFloat(),
+            (center.z - 0.5).toFloat()
+        )
+    }
+
     companion object {
 
+        private val ZERO_VEC = Vec3(0.0, 0.0, 0.0)
         private val ZERO_VECTOR = Vector3f()
+        private val ZERO_QUATERNION = Quaternionf()
+
+        private val REFRESH_IDS = listOf(
+            EntityDataAccess.DISPLAY_DATA_SCALE_ID,
+            EntityDataAccess.DISPLAY_DATA_TRANSLATION_ID
+        )
+
+        private val INTERPOLATION_IDS = listOf(
+            EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID,
+            EntityDataAccess.DISPLAY_DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID
+        )
 
         @JvmSynthetic
         internal val tickJob = Rebar.scope.launch {
@@ -322,14 +426,21 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
                             entity.stateWasUpdated = false
                         }
 
+                        if (entity.refreshesFrozen && entity.refreshesFrozenExpireTime < System.currentTimeMillis()) {
+                            entity.refreshesFrozen = false
+                        }
+
                         val trackedData = entity.entityData.packDirty() ?: continue
                         for (playerId in entity.viewers) {
-                            entity.sendPacket(playerId, entity.createDataPacket(playerId, distanceSquared(entity, playerId), trackedData, false) ?: continue)
+                            entity.sendPacket(playerId, entity.createDataPacketRaw(playerId, distanceSquared(entity, playerId), trackedData, false, false) ?: continue)
                         }
                     }
                 }
             }
         }
+
+        private val BlockState.hasLightingData: Boolean
+            get() = !(canOcclude() && `moonrise$occludesFullBlock`())
 
         private fun distanceSquared(entity: BlockTextureEntityImpl, playerId: UUID): Double {
             val player = Bukkit.getPlayer(playerId) ?: return 0.0

--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
@@ -98,6 +98,8 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
      * This is needed so that occluding blocks don't cause the entity to be rendered at 0 brightness
      */
     private var lightingOffset: Vector3f = ZERO_VECTOR
+    private var lightingUpdateCooldown: Long = 0
+    private var lightingUpdateScheduled: Boolean = false
 
     /**
      * The transformation of the texture entity needs to be centered on the bounding box of the block instead of the block center.
@@ -106,7 +108,7 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
     private var centerOffset: Vector3f
 
     var lastState: BlockState
-    var stateWasUpdated: Boolean = false
+    var stateUpdated: Boolean = false
 
     /**
      * A map of the last scale increase sent to each player, used to prevent sending unnecessary scale updates when the player is far enough away that the scale increase doesn't change anymore or when the change is by to small a margin
@@ -157,7 +159,7 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
         this.lastState = (block.block as CraftBlock).blockState
         this.lightingOffset = calculateLightingOffset()
         this.centerOffset = calculateCenterOffset()
-        updateLighting()
+        tryUpdateLighting()
     }
 
     val transformation: Transformation
@@ -300,7 +302,17 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
         }
     }
 
-    fun updateLighting(): Boolean {
+    fun tryUpdateLighting(): Boolean {
+        // Require at least 1 tick between lighting update attempts, we cannot just ignore
+        // all lighting update attempts within 1 tick because we are dealing with multiple possible
+        // light locations, so at the worst it gets scheduled to update the next tick.
+        if (lightingUpdateCooldown > System.currentTimeMillis()) {
+            lightingUpdateScheduled = true
+            return false
+        }
+        lightingUpdateCooldown = System.currentTimeMillis() + 50
+        lightingUpdateScheduled = false
+
         val originalDelegates = this.lightDelegatePositions
         val originalOffset = this.lightingOffset
         this.lightingOffset = calculateLightingOffset()
@@ -336,18 +348,18 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
     }
 
     fun tryUpdateState(): Boolean {
-        if (!stateWasUpdated) {
+        if (!stateUpdated) {
             val newState = (block.block as CraftBlock).blockState
             if (newState === lastState) return false
             lastState = newState
 
             block.refreshBlockTextureItem()
-            stateWasUpdated = updateLighting() || itemUpdateData.isDirty
-            if (stateWasUpdated) {
+            stateUpdated = tryUpdateLighting() || itemUpdateData.isDirty
+            if (stateUpdated) {
                 centerOffset = calculateCenterOffset()
             }
         }
-        return stateWasUpdated
+        return stateUpdated
     }
 
     private fun calculateLightingOffset(): Vector3f {
@@ -355,18 +367,18 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
             return ZERO_VECTOR
         }
 
-        // Check for the first direct neighboring block that has lighting data with the highest light
+        // Check for the direct neighboring block that has lighting data with the highest light
         var brightestFace: BlockFace? = null
         var brightest = lightingOffset
         var brightestLight = 0.toByte()
-        if (lightingOffset !== ZERO_VECTOR) {
-            val delegateBlock = block.block.getRelative(lightingOffset.x.toInt(), lightingOffset.y.toInt(), lightingOffset.z.toInt()) as? CraftBlock
+        if (brightest !== ZERO_VECTOR) {
+            val delegateBlock = block.block.getRelative(brightest.x.toInt(), brightest.y.toInt(), brightest.z.toInt()) as? CraftBlock
             if (delegateBlock?.blockState?.hasLightingData ?: false) {
                 brightestLight = delegateBlock.lightLevel
-                brightestFace = IMMEDIATE_FACES.firstOrNull { it.modX == lightingOffset.x.toInt() && it.modY == lightingOffset.y.toInt() && it.modZ == lightingOffset.z.toInt() }
+                if (brightestLight >= 15) return brightest
+                brightestFace = IMMEDIATE_FACES.firstOrNull { it.modX == brightest.x.toInt() && it.modY == brightest.y.toInt() && it.modZ == brightest.z.toInt() }
             }
         }
-
 
         for (face in IMMEDIATE_FACES) {
             if (brightestFace == face) continue
@@ -376,6 +388,7 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
                 if (light > brightestLight) {
                     brightestLight = light
                     brightest = Vector3f(face.modX.toFloat(), face.modY.toFloat(), face.modZ.toFloat())
+                    if (light >= 15) return brightest
                 }
             }
         }
@@ -422,8 +435,12 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
                         val entity = block.blockTextureEntity as? BlockTextureEntityImpl ?: continue
                         if (entity.viewers.isEmpty()) continue
 
-                        if (entity.stateWasUpdated) {
-                            entity.stateWasUpdated = false
+                        if (entity.stateUpdated) {
+                            entity.stateUpdated = false
+                        }
+
+                        if (entity.lightingUpdateScheduled) {
+                            entity.tryUpdateLighting()
                         }
 
                         if (entity.refreshesFrozen && entity.refreshesFrozenExpireTime < System.currentTimeMillis()) {

--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/packet/PlayerPacketHandler.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/packet/PlayerPacketHandler.kt
@@ -144,20 +144,20 @@ class PlayerPacketHandler(private val player: ServerPlayer, val handler: PlayerT
 
             is ClientboundBlockUpdatePacket -> packet.let {
                 val cullingJob = BlockCullingEngine.getCullingJob(player.uuid) ?: return@let it
-                val pos = BlockPosition.asLong(it.pos.x, it.pos.y, it.pos.z)
+                val packedPos = BlockPosition.asLong(it.pos.x, it.pos.y, it.pos.z)
 
-                return@let cullingJob.visible[pos]?.let { block ->
-                    if (!block.disableBlockTextureEntity && block.blockTextureEntity is BlockTextureEntityImpl) {
-                        val entity = block.blockTextureEntity as BlockTextureEntityImpl
-                        return@let if (entity.tryUpdateState()) ClientboundBundlePacket(mutableListOf(entity.itemUpdatePacket, it)) else it
-                    } else {
-                        return@let it
-                    }
-                } ?: cullingJob.lightDelegates[pos]?.let { delegates ->
+                cullingJob.lightDelegates[packedPos]?.let { delegates ->
                     for (delegate in delegates) {
                         if (!delegate.disableBlockTextureEntity && delegate.blockTextureEntity is BlockTextureEntityImpl) {
                             (delegate.blockTextureEntity as BlockTextureEntityImpl).updateLighting()
                         }
+                    }
+                }
+
+                return@let cullingJob.visible[packedPos]?.let { block ->
+                    if (!block.disableBlockTextureEntity && block.blockTextureEntity is BlockTextureEntityImpl) {
+                        val entity = block.blockTextureEntity as BlockTextureEntityImpl
+                        return@let if (entity.tryUpdateState()) ClientboundBundlePacket(mutableListOf(entity.itemUpdatePacket, it)) else it
                     }
                     return@let it
                 } ?: it
@@ -167,13 +167,23 @@ class PlayerPacketHandler(private val player: ServerPlayer, val handler: PlayerT
                 val cullingJob = BlockCullingEngine.getCullingJob(player.uuid) ?: return@let it
                 val packets = mutableListOf<Packet<in ClientGamePacketListener>>()
                 it.runUpdates { pos, _ ->
-                    val block = cullingJob.visible[BlockPosition.asLong(pos.x, pos.y, pos.z)] ?: return@runUpdates
-                    if (!block.disableBlockTextureEntity && block.blockTextureEntity is BlockTextureEntityImpl) {
-                        val entity = block.blockTextureEntity as BlockTextureEntityImpl
-                        if (entity.tryUpdateState()) {
-                            packets.add(entity.itemUpdatePacket)
-                        }
+                    val packedPos = BlockPosition.asLong(pos.x, pos.y, pos.z)
 
+                    cullingJob.lightDelegates[packedPos]?.let { delegates ->
+                        for (delegate in delegates) {
+                            if (!delegate.disableBlockTextureEntity && delegate.blockTextureEntity is BlockTextureEntityImpl) {
+                                (delegate.blockTextureEntity as BlockTextureEntityImpl).updateLighting()
+                            }
+                        }
+                    }
+
+                    cullingJob.visible[packedPos]?.let { block ->
+                        if (!block.disableBlockTextureEntity && block.blockTextureEntity is BlockTextureEntityImpl) {
+                            val entity = block.blockTextureEntity as BlockTextureEntityImpl
+                            if (entity.tryUpdateState()) {
+                                packets.add(entity.itemUpdatePacket)
+                            }
+                        }
                     }
                 }
                 return@let if (packets.isEmpty()) it else ClientboundBundlePacket(packets.apply { add(it) })

--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/packet/PlayerPacketHandler.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/packet/PlayerPacketHandler.kt
@@ -144,13 +144,23 @@ class PlayerPacketHandler(private val player: ServerPlayer, val handler: PlayerT
 
             is ClientboundBlockUpdatePacket -> packet.let {
                 val cullingJob = BlockCullingEngine.getCullingJob(player.uuid) ?: return@let it
-                val block = cullingJob.visible[BlockPosition.asLong(it.pos.x, it.pos.y, it.pos.z)] ?: return@let it
-                if (!block.disableBlockTextureEntity && block.blockTextureEntity is BlockTextureEntityImpl) {
-                    val entity = block.blockTextureEntity as BlockTextureEntityImpl
-                    return@let if (entity.tryUpdateState()) ClientboundBundlePacket(mutableListOf(entity.itemUpdatePacket, it)) else it
-                } else {
+                val pos = BlockPosition.asLong(it.pos.x, it.pos.y, it.pos.z)
+
+                return@let cullingJob.visible[pos]?.let { block ->
+                    if (!block.disableBlockTextureEntity && block.blockTextureEntity is BlockTextureEntityImpl) {
+                        val entity = block.blockTextureEntity as BlockTextureEntityImpl
+                        return@let if (entity.tryUpdateState()) ClientboundBundlePacket(mutableListOf(entity.itemUpdatePacket, it)) else it
+                    } else {
+                        return@let it
+                    }
+                } ?: cullingJob.lightDelegates[pos]?.let { delegates ->
+                    for (delegate in delegates) {
+                        if (!delegate.disableBlockTextureEntity && delegate.blockTextureEntity is BlockTextureEntityImpl) {
+                            (delegate.blockTextureEntity as BlockTextureEntityImpl).updateLighting()
+                        }
+                    }
                     return@let it
-                }
+                } ?: it
             }
 
             is ClientboundSectionBlocksUpdatePacket -> packet.let {

--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/packet/PlayerPacketHandler.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/packet/PlayerPacketHandler.kt
@@ -149,7 +149,7 @@ class PlayerPacketHandler(private val player: ServerPlayer, val handler: PlayerT
                 cullingJob.lightDelegates[packedPos]?.let { delegates ->
                     for (delegate in delegates) {
                         if (!delegate.disableBlockTextureEntity && delegate.blockTextureEntity is BlockTextureEntityImpl) {
-                            (delegate.blockTextureEntity as BlockTextureEntityImpl).updateLighting()
+                            (delegate.blockTextureEntity as BlockTextureEntityImpl).tryUpdateLighting()
                         }
                     }
                 }
@@ -172,7 +172,7 @@ class PlayerPacketHandler(private val player: ServerPlayer, val handler: PlayerT
                     cullingJob.lightDelegates[packedPos]?.let { delegates ->
                         for (delegate in delegates) {
                             if (!delegate.disableBlockTextureEntity && delegate.blockTextureEntity is BlockTextureEntityImpl) {
-                                (delegate.blockTextureEntity as BlockTextureEntityImpl).updateLighting()
+                                (delegate.blockTextureEntity as BlockTextureEntityImpl).tryUpdateLighting()
                             }
                         }
                     }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/RebarBlock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/RebarBlock.kt
@@ -153,15 +153,6 @@ open class RebarBlock private constructor(val block: Block) : Keyed {
         item.setData(DataComponentTypes.ITEM_MODEL, Key.key("air"))
         itemStack = item
         itemDisplayTransform = ItemDisplay.ItemDisplayTransform.FIXED
-        brightness = Display.Brightness(15, 15)
-        transformation = transformation.let {
-            Transformation(
-                it.translation,
-                it.leftRotation,
-                Vector3f(1 + BlockTextureEntity.BLOCK_OVERLAP_INCREASE),
-                it.rightRotation
-            )
-        }
         entity.spawn()
     }
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/culling/BlockCullingEngine.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/culling/BlockCullingEngine.kt
@@ -350,7 +350,7 @@ object BlockCullingEngine : Listener {
             .build()
     ) {
         fun insert(block: Block, isOccluding: Boolean = NmsAccessor.instance.isOccluding(block)) {
-            occluding.put(BlockPosition.asLong(block.x, block.y, block.z), isOccluding)
+            occluding.put(BlockPosition.asLong(block), isOccluding)
         }
 
         fun isOccluding(world: World, blockX: Int, blockY: Int, blockZ: Int): Boolean {

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/culling/PlayerCullingJob.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/culling/PlayerCullingJob.kt
@@ -26,10 +26,12 @@ import org.bukkit.util.BoundingBox
 import org.bukkit.util.Vector
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArraySet
 
 class PlayerCullingJob(
     val playerId: UUID,
     val visible: MutableMap<Long, RebarBlock> = ConcurrentHashMap(),
+    val lightDelegates: MutableMap<Long, MutableSet<RebarBlock>> = ConcurrentHashMap(),
     var tick: Int = 0
 ) {
     suspend fun run() {
@@ -59,7 +61,8 @@ class PlayerCullingJob(
                     val entity = block.blockTextureEntity ?: continue
                     val distanceSquared = block.block.distanceSquared(feet)
                     entity.addOrRefreshViewer(playerId, distanceSquared)
-                    visible[BlockPosition.asLong(block.block.x, block.block.y, block.block.z)] = block
+                    visible[BlockPosition.asLong(block.block)] = block
+                    entity.lightDelegatePositions.forEach { lightDelegates.getOrPut(it) { CopyOnWriteArraySet() }.add(block) }
                 }
             }
             delayTicks(RebarConfig.CullingEngineConfig.DISABLED_UPDATE_INTERVAL.toLong())
@@ -90,7 +93,11 @@ class PlayerCullingJob(
         val cullingGroups = mutableSetOf<RebarGroupCulledBlock.CullingGroup>()
 
         fun makeBlockVisible(block: RebarBlock, distanceSquared: Double) {
-            block.blockTextureEntity?.addOrRefreshViewer(playerId, distanceSquared)
+            block.blockTextureEntity?.apply {
+                addOrRefreshViewer(playerId, distanceSquared)
+                lightDelegatePositions.forEach { lightDelegates.getOrPut(it) { CopyOnWriteArraySet() }.add(block) }
+            }
+
             if (block is RebarGroupCulledBlock) {
                 cullingGroups.addAll(block.cullingGroups)
             } else if (block is RebarCulledBlock) {
@@ -100,11 +107,20 @@ class PlayerCullingJob(
                     syncTasks[block] = true
                 }
             }
-            visible[BlockPosition.asLong(block.block.x, block.block.y, block.block.z)] = block
+            visible[BlockPosition.asLong(block.block)] = block
         }
 
         fun makeBlockCulled(block: RebarBlock) {
-            block.blockTextureEntity?.removeViewer(playerId)
+            block.blockTextureEntity?.apply {
+                removeViewer(playerId)
+                for (delegate in lightDelegatePositions) {
+                    lightDelegates[delegate]?.apply {
+                        remove(block)
+                        if (isEmpty()) lightDelegates.remove(delegate)
+                    }
+                }
+            }
+
             if (block is RebarGroupCulledBlock) {
                 cullingGroups.addAll(block.cullingGroups)
             } else if (block is RebarCulledBlock) {
@@ -127,6 +143,10 @@ class PlayerCullingJob(
                 else -> entity?.hasViewer(playerId) ?: false
             }
 
+            // If its visible & we are on a visibleInterval tick, or if its hidden & we are on a hiddenInterval tick, do a culling check
+            val shouldCheck = (seen && tick % config.visibleInterval == 0) || (!seen && tick % config.hiddenInterval == 0)
+            if (!shouldCheck) continue
+
             // If we are within the always show radius, show, if we are outside cull radius, hide
             // (our query is a cube not a sphere, so blocks in the corners can still be outside the cull radius)
             val distanceSquared = block.block.distanceSquared(feet)
@@ -138,39 +158,36 @@ class PlayerCullingJob(
                 continue
             }
 
-            // If its visible & we are on a visibleInterval tick, or if its hidden & we are on a hiddenInterval tick, do a culling check
-            if ((seen && (tick % config.visibleInterval) == 0) || (!seen && (tick % config.hiddenInterval) == 0)) {
-                // TODO: Later if necessary, have a 3d scan using bounding boxes rather than a line
-                // Ray traces from the players eye to the center of the block, counting occluding blocks in between
-                // if its greater than the maxOccludingCount, hide the entity, otherwise show it
-                var occluding = 0
-                val end = Vector(block.block.x + 0.5, block.block.y + 0.5, block.block.z + 0.5)
-                val totalDistance = eye.distanceSquared(end)
-                val current = eye.clone()
-                val direction = end.clone().subtract(eye).normalize()
-                while (current.distanceSquared(eye) < totalDistance) {
-                    current.add(direction)
-                    if (current.distanceSquared(eye) > totalDistance) {
-                        current.copy(end)
-                    }
-
-                    val x = current.blockX
-                    val y = current.blockY
-                    val z = current.blockZ
-
-                    val chunkPos = Chunk.getChunkKey(x shr 4, z shr 4)
-                    val occludes = occludingCache.getOrPut(chunkPos) { ChunkData() }.isOccluding(world, x, y, z)
-                    if (occludes && ++occluding > config.maxOccludingCount) {
-                        break
-                    }
+            // TODO: Later if necessary, have a 3d scan using bounding boxes rather than a line
+            // Ray traces from the players eye to the center of the block, counting occluding blocks in between
+            // if its greater than the maxOccludingCount, hide the entity, otherwise show it
+            var occluding = 0
+            val end = Vector(block.block.x + 0.5, block.block.y + 0.5, block.block.z + 0.5)
+            val totalDistance = eye.distanceSquared(end)
+            val current = eye.clone()
+            val direction = end.clone().subtract(eye).normalize()
+            while (current.distanceSquared(eye) < totalDistance) {
+                current.add(direction)
+                if (current.distanceSquared(eye) > totalDistance) {
+                    current.copy(end)
                 }
 
-                val shouldSee = occluding <= config.maxOccludingCount
-                if (shouldSee) {
-                    makeBlockVisible(block, distanceSquared)
-                } else {
-                    makeBlockCulled(block)
+                val x = current.blockX
+                val y = current.blockY
+                val z = current.blockZ
+
+                val chunkPos = Chunk.getChunkKey(x shr 4, z shr 4)
+                val occludes = occludingCache.getOrPut(chunkPos) { ChunkData() }.isOccluding(world, x, y, z)
+                if (occludes && ++occluding > config.maxOccludingCount) {
+                    break
                 }
+            }
+
+            val shouldSee = occluding <= config.maxOccludingCount
+            if (shouldSee) {
+                makeBlockVisible(block, distanceSquared)
+            } else {
+                makeBlockCulled(block)
             }
         }
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/packet/BlockTextureEntity.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/packet/BlockTextureEntity.kt
@@ -5,24 +5,16 @@ import org.bukkit.Color
 import org.bukkit.entity.Display
 import org.bukkit.entity.ItemDisplay
 import org.bukkit.inventory.ItemStack
-import org.bukkit.util.Transformation
-import org.joml.Matrix4f
 import java.util.UUID
 
 interface BlockTextureEntity {
     val block: RebarBlock
+    val lightDelegatePositions: Iterable<Long>
     var id: Int
     var uuid: UUID
     val viewers: Set<UUID>
 
     val isSpawned: Boolean
-
-    var transformation: Transformation
-    var transformationMatrix: Matrix4f
-
-    var interpolationDelay: Int
-    var interpolationDuration: Int
-    var teleportDuration: Int
 
     var shadowRadius: Float
     var shadowStrength: Float
@@ -41,7 +33,7 @@ interface BlockTextureEntity {
     fun addOrRefreshViewer(playerId: UUID, distanceSquared: Double)
     fun refreshViewer(playerId: UUID, distanceSquared: Double)
     fun hasViewer(playerId: UUID): Boolean
-    fun removeViewer(playerId: UUID)
+    fun removeViewer(playerId: UUID): Boolean
     fun removeAllViewers()
 
     fun spawn()
@@ -71,8 +63,8 @@ interface BlockTextureEntity {
             BLOCK_OVERLAP_INCREASE / (DOUBLE_OVERLAP_INCREASE_DISTANCE * DOUBLE_OVERLAP_INCREASE_DISTANCE)
 
         /**
-         * If the difference between the new scale increase and the last scale increase sent to the viewer is less than 1/10th of the base BLOCK_OVERLAP_SCALE, we don't send a packet to avoid unnecessary packet spam.
+         * If the difference between the new scale increase and the last scale increase sent to the viewer is less than 1/3 of the base BLOCK_OVERLAP_SCALE, we don't send a packet to avoid unnecessary packet spam.
          */
-        const val SCALE_DISTANCE_THRESHOLD = BLOCK_OVERLAP_INCREASE / 10.0f
+        const val SCALE_DISTANCE_THRESHOLD = BLOCK_OVERLAP_INCREASE / 3.0f
     }
 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/util/position/BlockPosition.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/util/position/BlockPosition.kt
@@ -123,6 +123,10 @@ class BlockPosition(val worldId: UUID?, val x: Int, val y: Int, val z: Int) {
         get() = world?.getBlockAt(x, y, z) ?: error("World is null")
 
     companion object {
+        fun asLong(block: Block): Long {
+            return asLong(block.x, block.y, block.z)
+        }
+
         fun asLong(x: Int, y: Int, z: Int): Long {
             return ((x and 0x3FFFFFF).toLong() shl 38)
                 .or((z and 0x3FFFFFF).toLong() shl 12)


### PR DESCRIPTION
Fixes #634 

In order to give accurate lighting information we have to move the location of the entity to a block that has lighting data, specifically the one with the most light. of the rebar block itself is transparent then it will have lighting data (think glass) and we don't have to do anything, but if its opaque (think copper block) then we have to delegate to a neighbor that has the most light

that also means we have to watch for the neighbors changing

I removed the ability to change the transformation of the base BlockTextureEntity interface so that I can safely in the impl avoid sending unnecessary data.

In this I also fix a couple of bugs in the related systems (i.e. making a rebar block visible/culled every tick if it was within the always show radius or outside the cull radius instead of following the visible/hidden intervals)