### PR TITLE
fix: delegate null-cost research lore to addon unlock-instructions in ItemButton

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/button/ItemButton.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/button/ItemButton.kt
@@ -93,7 +93,12 @@ class ItemButton @JvmOverloads constructor(
                             RebarArgument.of("unlock_cost", UnitFormat.RESEARCH_POINTS.format(research.cost))
                         )
                     } else {
-                        Component.translatable("rebar.guide.button.item.not-researched")
+                        // Null-cost research uses a custom unlock flow defined by the addon.
+                        // Delegate to the addon's unlock-instructions key, mirroring
+                        // ResearchButton's handling of the same case.
+                        Component.translatable(
+                            "${research.key.namespace}.researches.${research.key.key}.unlock-instructions"
+                        )
                     }
 
                     val lore = builder.lore()?.lines()?.toMutableList() ?: mutableListOf()


### PR DESCRIPTION
## Problem

`ItemButton.getItemProvider` renders `guide.button.item.not-researched` for researches whose `cost == null` (custom unlock flow, no research points). That key is a **YAML section** in the lang file (it has `no-research-cost`, `enough-points`, `not-enough-points` children), not a string. `RebarTranslator` reads it via `ConfigAdapter.STRING` which calls `toString()` on the `MemorySection`, so the player sees:

```
MemorySection[path='guide.button.item.not-researched',root='YamlConfiguration']
```

This appears on item buttons in the main guide page, recipe detail pages, **and** vanilla crafting pages — anywhere `ItemButton` is used to display a locked item.

## Fix

`ResearchButton` already handles `cost == null` correctly by delegating to `<namespace>.researches.<key>.unlock-instructions`, letting the addon describe its own unlock flow. This PR aligns `ItemButton` with the same behaviour.

```kotlin
// before
Component.translatable("rebar.guide.button.item.not-researched")

// after
Component.translatable(
    "${research.key.namespace}.researches.${research.key.key}.unlock-instructions"
)
```

Addons that use null-cost researches can now provide a meaningful lore line on item buttons (e.g. "Requires 80 Material discipline points — unlock via Science Interface") rather than seeing garbled text.

## Reproduce

1. Register a `Research` with `cost = null` and add an item to its `unlocks` set.
2. Open the Rebar guide while the research is not yet unlocked.
3. Any `ItemButton` showing that item displays `MemorySection[...]` as the first lore line.