### PR TITLE
fix(guide): restore @ prefix search for raw namespace and display name

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/base/SearchPage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/base/SearchPage.kt
@@ -94,7 +94,11 @@ abstract class SearchPage(key: NamespacedKey) : SimpleStaticGuidePage(key) {
             if (piece.isEmpty() || (piece[0] == '@' || piece[0] == '$') && piece.length == 1) continue
             val predicate = when(piece[0]) {
                 '@' -> { entry: Pair<Item, String> ->
-                    getDisplayNamespace(entry.first, player).contains(piece.substring(1), true)
+                    val searchTerm = piece.substring(1)
+                    val key = getItemKey(entry.first, player)
+                    key.namespace.startsWith(searchTerm, true) ||
+                        getDisplayNamespace(entry.first, player).replace(" ", "")
+                            .startsWith(searchTerm, true)
                 }
                 '$' -> { entry: Pair<Item, String> ->
                     entry.first.getItemProvider(player).get().lore()?.any { it.plainText.contains(piece.substring(1), true) } ?: false
@@ -108,9 +112,15 @@ abstract class SearchPage(key: NamespacedKey) : SimpleStaticGuidePage(key) {
         return entries.map { it.first }.toList()
     }
 
-    fun getDisplayNamespace(item: Item, player: Player): String {
+    private fun getItemKey(item: Item, player: Player): NamespacedKey {
         val itemStack = item.getItemProvider(player).get()
-        val key = RebarItemSchema.fromStack(itemStack)?.key ?: RebarFluid.fromStack(itemStack)?.key ?: itemStack.type.key
+        return RebarItemSchema.fromStack(itemStack)?.key
+            ?: RebarFluid.fromStack(itemStack)?.key
+            ?: itemStack.type.key
+    }
+
+    fun getDisplayNamespace(item: Item, player: Player): String {
+        val key = getItemKey(item, player)
         val addon = RebarRegistry.ADDONS[NamespacedKey(key.namespace, key.namespace)]
         return addon?.let { GlobalTranslator.render(addon.footerName, player.locale()).plainText.lowercase() } ?: key.namespace
     }


### PR DESCRIPTION
Fixes searching by addon id with @ prefix.

## Problem
The @ prefix search in the guide only matched the translated footerName (display name) using substring contains. This meant searching for @rebarmobs would not match items from the 'rebar mobs' addon, because 'rebar mobs'.contains('rebarmobs') is false.

## Solution
- Extract getItemKey helper to avoid code duplication
- @ search now matches both:
  - Raw namespace via startsWith (e.g. @rebarmobs matches namespace 'rebarmobs')
  - Display name with spaces removed via startsWith (e.g. @rebarmobs matches 'rebar mobs' → 'rebarmobs')

This restores the functionality from #373 which was lost during a refactor.

## Testing
- [x] Compiled successfully with ./gradlew :rebar:compileKotlin