### PR TITLE
Waila Suppliers

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/BlockStorage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/BlockStorage.kt
@@ -637,6 +637,8 @@ object BlockStorage : Listener {
         blocksByKey.computeIfAbsent(phantomBlock.key) { mutableListOf() }.add(phantomBlock)
         blocksByChunk[block.block.chunk.position]!!.remove(block)
         blocksByChunk[phantomBlock.block.chunk.position]!!.add(phantomBlock)
+
+        RebarBlockPhantomEvent(block.block, block, phantomBlock).callEvent()
     }
 
     @JvmSynthetic

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/RebarBlock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/RebarBlock.kt
@@ -24,6 +24,7 @@ import io.github.pylonmc.rebar.util.position.BlockPosition
 import io.github.pylonmc.rebar.util.position.position
 import io.github.pylonmc.rebar.util.rebarKey
 import io.github.pylonmc.rebar.waila.WailaDisplay
+import io.github.pylonmc.rebar.waila.WailaSupplier
 import io.papermc.paper.datacomponent.DataComponentTypes
 import net.kyori.adventure.key.Key
 import org.bukkit.*
@@ -51,7 +52,7 @@ import org.joml.Vector3f
  *
  * @see BlockStorage
  */
-open class RebarBlock private constructor(val block: Block) : Keyed {
+open class RebarBlock private constructor(val block: Block) : WailaSupplier, Keyed {
 
     /**
      * All the data needed to create or load the block.
@@ -217,7 +218,7 @@ open class RebarBlock private constructor(val block: Block) : Keyed {
      *
      * @return the WAILA configuration, or null if WAILA should not be shown for this block.
      */
-    open fun getWaila(player: Player): WailaDisplay? {
+    override fun getWaila(player: Player): WailaDisplay? {
         return WailaDisplay(defaultWailaTranslationKey)
     }
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/interfaces/SimpleRebarMultiblock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/interfaces/SimpleRebarMultiblock.kt
@@ -13,7 +13,6 @@ import io.github.pylonmc.rebar.util.position.ChunkPosition
 import io.github.pylonmc.rebar.util.position.position
 import io.github.pylonmc.rebar.util.rebarKey
 import io.github.pylonmc.rebar.util.rotateVectorToFace
-import io.github.pylonmc.rebar.waila.RebarBlockWailaSupplier
 import io.github.pylonmc.rebar.waila.Waila
 import io.github.pylonmc.rebar.waila.WailaDisplay
 import org.bukkit.Color
@@ -289,7 +288,7 @@ interface SimpleRebarMultiblock : RebarMultiblock, GhostBlockHolderRebarBlock, E
             removeGhostBlock(getRotatedPosition(position))
         }
         for (position in components.keys) {
-            Waila.addWailaOverride(getMultiblockBlock(position), RebarBlockWailaSupplier(this as RebarBlock))
+            Waila.addWailaOverride(getMultiblockBlock(position), this as RebarBlock)
         }
     }
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/interfaces/SimpleRebarMultiblock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/interfaces/SimpleRebarMultiblock.kt
@@ -1,6 +1,7 @@
 package io.github.pylonmc.rebar.block.interfaces
 
 import io.github.pylonmc.rebar.block.BlockStorage
+import io.github.pylonmc.rebar.block.RebarBlock
 import io.github.pylonmc.rebar.block.context.BlockCreateContext
 import io.github.pylonmc.rebar.datatypes.RebarSerializers
 import io.github.pylonmc.rebar.event.RebarBlockDeserializeEvent
@@ -12,6 +13,7 @@ import io.github.pylonmc.rebar.util.position.ChunkPosition
 import io.github.pylonmc.rebar.util.position.position
 import io.github.pylonmc.rebar.util.rebarKey
 import io.github.pylonmc.rebar.util.rotateVectorToFace
+import io.github.pylonmc.rebar.waila.RebarBlockWailaSupplier
 import io.github.pylonmc.rebar.waila.Waila
 import io.github.pylonmc.rebar.waila.WailaDisplay
 import org.bukkit.Color
@@ -287,7 +289,7 @@ interface SimpleRebarMultiblock : RebarMultiblock, GhostBlockHolderRebarBlock, E
             removeGhostBlock(getRotatedPosition(position))
         }
         for (position in components.keys) {
-            Waila.addWailaOverride(getMultiblockBlock(position), this::getWaila)
+            Waila.addWailaOverride(getMultiblockBlock(position), RebarBlockWailaSupplier(this as RebarBlock))
         }
     }
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/RebarEntity.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/RebarEntity.kt
@@ -10,6 +10,8 @@ import io.github.pylonmc.rebar.event.RebarEntitySerializeEvent
 import io.github.pylonmc.rebar.registry.RebarRegistry
 import io.github.pylonmc.rebar.util.rebarKey
 import io.github.pylonmc.rebar.waila.WailaDisplay
+import io.github.pylonmc.rebar.waila.WailaSupplier
+import org.bukkit.Keyed
 import org.bukkit.NamespacedKey
 import org.bukkit.entity.Entity
 import org.bukkit.entity.Player
@@ -28,12 +30,14 @@ import org.bukkit.persistence.PersistentDataContainer
  * Rebar blocks. This is because it doesn't make sense for Rebar to manage spawning entities. However, your
  * entity must still have a load constructor that takes a single parameter of type [E].
  */
-abstract class RebarEntity<out E: Entity>(val entity: E) {
+abstract class RebarEntity<out E: Entity>(val entity: E) : WailaSupplier, Keyed {
 
     val key = entity.persistentDataContainer.get(rebarEntityKeyKey, RebarSerializers.NAMESPACED_KEY)
         ?: throw IllegalStateException("Entity did not have a Rebar key; did you mean to call RebarEntity(NamespacedKey, Entity) instead of RebarEntity(Entity)?")
     val schema = RebarRegistry.ENTITIES.getOrThrow(key)
     val uuid = entity.uniqueId
+
+    override fun getKey(): NamespacedKey = schema.key
 
     constructor(key: NamespacedKey, entity: E): this(initialiseRebarEntity<E>(key, entity))
 
@@ -45,7 +49,7 @@ abstract class RebarEntity<out E: Entity>(val entity: E) {
      *
      * @return the WAILA configuration, or null if WAILA should not be shown for this block.
      */
-    open fun getWaila(player: Player): WailaDisplay? = null
+    override fun getWaila(player: Player): WailaDisplay? = null
 
     /**
      * Returns the item that should be given when the entity is middle clicked.

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/RebarEntity.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/RebarEntity.kt
@@ -32,12 +32,12 @@ import org.bukkit.persistence.PersistentDataContainer
  */
 abstract class RebarEntity<out E: Entity>(val entity: E) : WailaSupplier, Keyed {
 
-    val key = entity.persistentDataContainer.get(rebarEntityKeyKey, RebarSerializers.NAMESPACED_KEY)
+    @JvmField val key = entity.persistentDataContainer.get(rebarEntityKeyKey, RebarSerializers.NAMESPACED_KEY)
         ?: throw IllegalStateException("Entity did not have a Rebar key; did you mean to call RebarEntity(NamespacedKey, Entity) instead of RebarEntity(Entity)?")
     val schema = RebarRegistry.ENTITIES.getOrThrow(key)
     val uuid = entity.uniqueId
 
-    override fun getKey(): NamespacedKey = schema.key
+    override fun getKey() = key
 
     constructor(key: NamespacedKey, entity: E): this(initialiseRebarEntity<E>(key, entity))
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/event/RebarBlockPhantomEvent.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/event/RebarBlockPhantomEvent.kt
@@ -1,0 +1,25 @@
+package io.github.pylonmc.rebar.event
+
+import io.github.pylonmc.rebar.block.PhantomBlock
+import io.github.pylonmc.rebar.block.RebarBlock
+import org.bukkit.block.Block
+import org.bukkit.event.Event
+import org.bukkit.event.HandlerList
+
+/**
+ * Called when a [RebarBlock] turns into a [PhantomBlock] due to errors or the command.
+ */
+class RebarBlockPhantomEvent(
+    val block: Block,
+    val rebarBlock: RebarBlock,
+    val phantomBlock: PhantomBlock
+) : Event() {
+
+    override fun getHandlers(): HandlerList
+        = handlerList
+
+    companion object {
+        @JvmStatic
+        val handlerList: HandlerList = HandlerList()
+    }
+}

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/waila/Waila.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/waila/Waila.kt
@@ -356,13 +356,13 @@ class Waila private constructor(private val player: Player, playerConfig: Player
         }
 
         private fun removeOverrides(block: RebarBlock) {
-            blockOverrides.values.removeIf { supplier -> supplier is RebarBlockWailaSupplier && supplier.source == block }
-            entityOverrides.values.removeIf { supplier -> supplier is RebarBlockWailaSupplier && supplier.source == block }
+            blockOverrides.values.removeIf { it === block }
+            entityOverrides.values.removeIf { it === block }
         }
 
         private fun removeOverrides(entity: RebarEntity<*>) {
-            blockOverrides.values.removeIf { supplier -> supplier is RebarEntityWailaSupplier && supplier.source == entity }
-            entityOverrides.values.removeIf { supplier -> supplier is RebarEntityWailaSupplier && supplier.source == entity }
+            blockOverrides.values.removeIf { it === entity }
+            entityOverrides.values.removeIf { it === entity }
         }
 
         @EventHandler(priority = EventPriority.MONITOR)

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/waila/Waila.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/waila/Waila.kt
@@ -7,14 +7,17 @@ import io.github.pylonmc.rebar.config.RebarConfig
 import io.github.pylonmc.rebar.datatypes.RebarSerializers
 import io.github.pylonmc.rebar.entity.EntityStorage
 import io.github.pylonmc.rebar.entity.RebarEntity
+import io.github.pylonmc.rebar.event.RebarBlockBreakEvent
+import io.github.pylonmc.rebar.event.RebarBlockUnloadEvent
 import io.github.pylonmc.rebar.event.RebarBlockWailaEvent
+import io.github.pylonmc.rebar.event.RebarEntityDeathEvent
+import io.github.pylonmc.rebar.event.RebarEntityUnloadEvent
 import io.github.pylonmc.rebar.event.RebarEntityWailaEvent
 import io.github.pylonmc.rebar.i18n.RebarArgument
 import io.github.pylonmc.rebar.util.delayTicks
 import io.github.pylonmc.rebar.util.position.BlockPosition
 import io.github.pylonmc.rebar.util.position.position
 import io.github.pylonmc.rebar.util.rebarKey
-import io.github.pylonmc.rebar.util.vanillaDisplayName
 import io.github.pylonmc.rebar.waila.Waila.Companion.addWailaOverride
 import io.papermc.paper.raytracing.RayTraceTarget
 import kotlinx.coroutines.Job
@@ -151,7 +154,7 @@ class Waila private constructor(private val player: Player, playerConfig: Player
 
         rayTraceResult.hitEntity?.let { entity ->
             try {
-                var display = entityOverrides[entity.uniqueId]?.invoke(player)
+                var display = entityOverrides[entity.uniqueId]?.getWaila(player)
                     ?: entity.let(EntityStorage::get)?.getWaila(player)
 
                 if (display == null && player.wailaConfig.vanillaWailaEnabled) {
@@ -181,7 +184,7 @@ class Waila private constructor(private val player: Player, playerConfig: Player
 
         rayTraceResult.hitBlock?.let { block ->
             try {
-                var display = blockOverrides[block.position]?.invoke(player)
+                var display = blockOverrides[block.position]?.getWaila(player)
                     ?: block.let(BlockStorage::get)?.getWaila(player)
 
                 if (display == null && player.wailaConfig.vanillaWailaEnabled) {
@@ -216,8 +219,8 @@ class Waila private constructor(private val player: Player, playerConfig: Player
         private val wailaKey = rebarKey("waila")
         private val wailas = mutableMapOf<UUID, Waila>()
 
-        private val blockOverrides = mutableMapOf<BlockPosition, (Player) -> WailaDisplay?>()
-        private val entityOverrides = mutableMapOf<UUID, (Player) -> WailaDisplay?>()
+        private val blockOverrides = mutableMapOf<BlockPosition, WailaSupplier>()
+        private val entityOverrides = mutableMapOf<UUID, WailaSupplier>()
 
         @JvmStatic
         fun getWaila(player: Player): Waila? {
@@ -285,8 +288,8 @@ class Waila private constructor(private val player: Player, playerConfig: Player
          * old override will be replaced.
          */
         @JvmStatic
-        fun addWailaOverride(position: BlockPosition, provider: (Player) -> WailaDisplay?) {
-            blockOverrides[position] = provider
+        fun addWailaOverride(position: BlockPosition, supplier: WailaSupplier) {
+            blockOverrides[position] = supplier
         }
 
         /**
@@ -299,8 +302,8 @@ class Waila private constructor(private val player: Player, playerConfig: Player
          * old override will be replaced.
          */
         @JvmStatic
-        fun addWailaOverride(block: Block, provider: (Player) -> WailaDisplay?)
-                = addWailaOverride(block.position, provider)
+        fun addWailaOverride(block: Block, supplier: WailaSupplier)
+                = addWailaOverride(block.position, supplier)
 
         /**
          * Adds a WAILA override for the given entity. This will always show the
@@ -311,8 +314,8 @@ class Waila private constructor(private val player: Player, playerConfig: Player
          * old override will be replaced.
          */
         @JvmStatic
-        fun addWailaOverride(entity: Entity, provider: (Player) -> WailaDisplay?) {
-            entityOverrides[entity.uniqueId] = provider
+        fun addWailaOverride(entity: Entity, supplier: WailaSupplier) {
+            entityOverrides[entity.uniqueId] = supplier
         }
 
         /**
@@ -349,6 +352,31 @@ class Waila private constructor(private val player: Player, playerConfig: Player
         @EventHandler(priority = EventPriority.MONITOR)
         private fun onPlayerQuit(event: PlayerQuitEvent) {
             removePlayer(event.player)
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR)
+        private fun onBlockBreak(event: RebarBlockBreakEvent) {
+            blockOverrides.values.removeIf { supplier -> supplier is RebarBlockWailaSupplier && supplier.source == event.rebarBlock }
+            entityOverrides.values.removeIf { supplier -> supplier is RebarBlockWailaSupplier && supplier.source == event.rebarBlock }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR)
+        private fun onBlockUnload(event: RebarBlockUnloadEvent) {
+            blockOverrides.values.removeIf { supplier -> supplier is RebarBlockWailaSupplier && supplier.source == event.rebarBlock }
+            entityOverrides.values.removeIf { supplier -> supplier is RebarBlockWailaSupplier && supplier.source == event.rebarBlock }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR)
+        private fun onEntityRemove(event: RebarEntityDeathEvent) {
+            // TODO: this will need changed to RebarEntityRemoveEvent when my other PR is opened & merged
+            blockOverrides.values.removeIf { supplier -> supplier is RebarEntityWailaSupplier && supplier.source == event.rebarEntity }
+            entityOverrides.values.removeIf { supplier -> supplier is RebarEntityWailaSupplier && supplier.source == event.rebarEntity }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR)
+        private fun onEntityUnload(event: RebarEntityUnloadEvent) {
+            blockOverrides.values.removeIf { supplier -> supplier is RebarEntityWailaSupplier && supplier.source == event.rebarEntity }
+            entityOverrides.values.removeIf { supplier -> supplier is RebarEntityWailaSupplier && supplier.source == event.rebarEntity }
         }
     }
 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/waila/Waila.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/waila/Waila.kt
@@ -8,6 +8,7 @@ import io.github.pylonmc.rebar.datatypes.RebarSerializers
 import io.github.pylonmc.rebar.entity.EntityStorage
 import io.github.pylonmc.rebar.entity.RebarEntity
 import io.github.pylonmc.rebar.event.RebarBlockBreakEvent
+import io.github.pylonmc.rebar.event.RebarBlockPhantomEvent
 import io.github.pylonmc.rebar.event.RebarBlockUnloadEvent
 import io.github.pylonmc.rebar.event.RebarBlockWailaEvent
 import io.github.pylonmc.rebar.event.RebarEntityDeathEvent
@@ -354,29 +355,40 @@ class Waila private constructor(private val player: Player, playerConfig: Player
             removePlayer(event.player)
         }
 
+        private fun removeOverrides(block: RebarBlock) {
+            blockOverrides.values.removeIf { supplier -> supplier is RebarBlockWailaSupplier && supplier.source == block }
+            entityOverrides.values.removeIf { supplier -> supplier is RebarBlockWailaSupplier && supplier.source == block }
+        }
+
+        private fun removeOverrides(entity: RebarEntity<*>) {
+            blockOverrides.values.removeIf { supplier -> supplier is RebarEntityWailaSupplier && supplier.source == entity }
+            entityOverrides.values.removeIf { supplier -> supplier is RebarEntityWailaSupplier && supplier.source == entity }
+        }
+
         @EventHandler(priority = EventPriority.MONITOR)
         private fun onBlockBreak(event: RebarBlockBreakEvent) {
-            blockOverrides.values.removeIf { supplier -> supplier is RebarBlockWailaSupplier && supplier.source == event.rebarBlock }
-            entityOverrides.values.removeIf { supplier -> supplier is RebarBlockWailaSupplier && supplier.source == event.rebarBlock }
+            removeOverrides(event.rebarBlock)
         }
 
         @EventHandler(priority = EventPriority.MONITOR)
         private fun onBlockUnload(event: RebarBlockUnloadEvent) {
-            blockOverrides.values.removeIf { supplier -> supplier is RebarBlockWailaSupplier && supplier.source == event.rebarBlock }
-            entityOverrides.values.removeIf { supplier -> supplier is RebarBlockWailaSupplier && supplier.source == event.rebarBlock }
+            removeOverrides(event.rebarBlock)
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR)
+        private fun onBlockPhantom(event: RebarBlockPhantomEvent) {
+            removeOverrides(event.rebarBlock)
         }
 
         @EventHandler(priority = EventPriority.MONITOR)
         private fun onEntityRemove(event: RebarEntityDeathEvent) {
             // TODO: this will need changed to RebarEntityRemoveEvent when my other PR is opened & merged
-            blockOverrides.values.removeIf { supplier -> supplier is RebarEntityWailaSupplier && supplier.source == event.rebarEntity }
-            entityOverrides.values.removeIf { supplier -> supplier is RebarEntityWailaSupplier && supplier.source == event.rebarEntity }
+            removeOverrides(event.rebarEntity)
         }
 
         @EventHandler(priority = EventPriority.MONITOR)
         private fun onEntityUnload(event: RebarEntityUnloadEvent) {
-            blockOverrides.values.removeIf { supplier -> supplier is RebarEntityWailaSupplier && supplier.source == event.rebarEntity }
-            entityOverrides.values.removeIf { supplier -> supplier is RebarEntityWailaSupplier && supplier.source == event.rebarEntity }
+            removeOverrides(event.rebarEntity)
         }
     }
 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/waila/WailaSupplier.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/waila/WailaSupplier.kt
@@ -1,22 +1,8 @@
 package io.github.pylonmc.rebar.waila
 
-import io.github.pylonmc.rebar.block.RebarBlock
-import io.github.pylonmc.rebar.entity.RebarEntity
 import org.bukkit.entity.Player
 
 @FunctionalInterface
 fun interface WailaSupplier {
     fun getWaila(player: Player): WailaDisplay?
-}
-
-class RebarBlockWailaSupplier(
-    val source: RebarBlock
-) : WailaSupplier {
-    override fun getWaila(player: Player): WailaDisplay? = source.getWaila(player)
-}
-
-class RebarEntityWailaSupplier(
-    val source: RebarEntity<*>
-) : WailaSupplier {
-    override fun getWaila(player: Player): WailaDisplay? = source.getWaila(player)
 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/waila/WailaSupplier.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/waila/WailaSupplier.kt
@@ -1,0 +1,22 @@
+package io.github.pylonmc.rebar.waila
+
+import io.github.pylonmc.rebar.block.RebarBlock
+import io.github.pylonmc.rebar.entity.RebarEntity
+import org.bukkit.entity.Player
+
+@FunctionalInterface
+fun interface WailaSupplier {
+    fun getWaila(player: Player): WailaDisplay?
+}
+
+class RebarBlockWailaSupplier(
+    val source: RebarBlock
+) : WailaSupplier {
+    override fun getWaila(player: Player): WailaDisplay? = source.getWaila(player)
+}
+
+class RebarEntityWailaSupplier(
+    val source: RebarEntity<*>
+) : WailaSupplier {
+    override fun getWaila(player: Player): WailaDisplay? = source.getWaila(player)
+}


### PR DESCRIPTION
adds waila suppliers so that we can have auto cleanup of proxy waila overrides, also adds RebarBlockPhantomEvent so that we can cleanup waila suppliers whenever a block turns into a phantom block (and anything else that needs to handle turning into phantom blocks can now use this event)