### PR TITLE
Batch Recipe (Un)Registration

### DIFF
--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessorImpl.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessorImpl.kt
@@ -8,17 +8,19 @@ import io.github.pylonmc.rebar.async.PlayerScope
 import io.github.pylonmc.rebar.block.RebarBlock
 import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity
 import io.github.pylonmc.rebar.i18n.PlayerTranslationHandler
-import io.github.pylonmc.rebar.nms.packet.PlayerPacketHandler
 import io.github.pylonmc.rebar.item.ItemTypeWrapper
 import io.github.pylonmc.rebar.nms.entity.BlockTextureEntityImpl
 import io.github.pylonmc.rebar.nms.inventory.KeyedContainerListener
+import io.github.pylonmc.rebar.nms.packet.PlayerPacketHandler
 import io.github.pylonmc.rebar.nms.recipe.AccessibleCachedCheck
 import io.github.pylonmc.rebar.nms.recipe.HandlerRecipeBookClick
+import io.github.pylonmc.rebar.nms.recipe.RecipeMapper
 import io.github.pylonmc.rebar.util.position.BlockPosition
 import io.papermc.paper.adventure.PaperAdventure
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.kyori.adventure.text.Component
+import net.minecraft.advancements.AdvancementRewards.Builder.recipe
 import net.minecraft.commands.arguments.item.ItemParser
 import net.minecraft.core.BlockPos
 import net.minecraft.core.registries.Registries
@@ -35,6 +37,7 @@ import net.minecraft.world.item.crafting.RecipeManager
 import net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity
 import net.minecraft.world.level.block.state.properties.Property
 import net.minecraft.world.phys.BlockHitResult
+import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
 import org.bukkit.World
@@ -42,29 +45,24 @@ import org.bukkit.block.Block
 import org.bukkit.block.BlockFace
 import org.bukkit.craftbukkit.CraftEquipmentSlot
 import org.bukkit.craftbukkit.CraftRegistry
+import org.bukkit.craftbukkit.CraftServer
 import org.bukkit.craftbukkit.CraftWorld
 import org.bukkit.craftbukkit.block.CraftBlock
 import org.bukkit.craftbukkit.entity.CraftEntity
 import org.bukkit.craftbukkit.entity.CraftLivingEntity
 import org.bukkit.craftbukkit.entity.CraftPlayer
-import org.bukkit.craftbukkit.inventory.CraftInventory
-import org.bukkit.craftbukkit.inventory.CraftInventoryView
-import org.bukkit.craftbukkit.inventory.CraftItemStack
-import org.bukkit.craftbukkit.inventory.CraftItemType
+import org.bukkit.craftbukkit.inventory.*
 import org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer
 import org.bukkit.craftbukkit.util.CraftNamespacedKey
 import org.bukkit.entity.Entity
 import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Player
-import org.bukkit.inventory.EquipmentSlot
-import org.bukkit.inventory.Inventory
-import org.bukkit.inventory.InventoryView
-import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.*
 import org.bukkit.persistence.PersistentDataContainer
 import java.lang.invoke.MethodHandle
 import java.lang.invoke.MethodHandles
 import java.lang.reflect.Field
-import java.util.UUID
+import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.max
@@ -307,6 +305,35 @@ object NmsAccessorImpl : NmsAccessor {
             val nmsDirection = CraftBlock.blockFaceToNotch(blockFace) ?: throw IllegalArgumentException("Invalid block face $blockFace")
             val nmsLoc = nmsPos.center.add(nmsDirection.unitVec3.scale(0.5))
             nmsPlayer.gameMode.useItemOn(nmsPlayer, level, nmsStack, nmsHand, BlockHitResult(nmsLoc, nmsDirection, nmsPos, false))
+        }
+    }
+
+    override fun hasRecipe(key: NamespacedKey): Boolean {
+        return MinecraftServer.getServer().recipeManager.recipes.byKey(CraftNamespacedKey.toResourceKey(Registries.RECIPE, key)) != null
+    }
+
+    override fun registerRecipes(recipes: Iterable<Recipe>, finalize: Boolean) {
+        val nmsRecipes = recipes.map(RecipeMapper::convertBukkitRecipe)
+        val recipeManager = MinecraftServer.getServer().recipeManager
+        for (recipe in nmsRecipes) {
+            recipeManager.recipes.addRecipe(recipe)
+        }
+
+        if (finalize) {
+            recipeManager.finalizeRecipeLoading()
+        }
+    }
+
+    override fun unregisterRecipes(recipes: Iterable<NamespacedKey>, finalize: Boolean) {
+        val recipeManager = MinecraftServer.getServer().recipeManager
+        var anyRemoved = false
+        for (recipeKey in recipes) {
+            val id = CraftNamespacedKey.toResourceKey(Registries.RECIPE, recipeKey)
+            anyRemoved = recipeManager.recipes.removeRecipe(id) || anyRemoved
+        }
+
+        if (finalize && anyRemoved) {
+            recipeManager.finalizeRecipeLoading()
         }
     }
 }

--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessorImpl.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessorImpl.kt
@@ -273,14 +273,14 @@ object NmsAccessorImpl : NmsAccessor {
         }
 
         try {
-            val reader = StringReader(input)
-            val itemInput = ItemParser(CraftRegistry.getMinecraftRegistry()).parse(reader);
-            if (reader.canRead()) {
+            val reader = if (input.isBlank()) null else StringReader(input)
+            val itemInput = if (input.isBlank()) null else ItemParser(CraftRegistry.getMinecraftRegistry()).parse(reader!!);
+            if (reader != null && reader.canRead()) {
                 throw IllegalArgumentException("Trailing input found when parsing ItemStack: " + reader.remaining);
             } else {
                 val stack = type.createItemStack()
                 val nmsStack = (stack as CraftItemStack).handle
-                nmsStack.applyComponents(itemInput.components)
+                itemInput?.let { nmsStack.applyComponents(it.components) }
                 return nmsStack.asBukkitMirror()
             }
         } catch (ex: CommandSyntaxException) {

--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessorImpl.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessorImpl.kt
@@ -9,6 +9,7 @@ import io.github.pylonmc.rebar.block.RebarBlock
 import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity
 import io.github.pylonmc.rebar.i18n.PlayerTranslationHandler
 import io.github.pylonmc.rebar.item.ItemTypeWrapper
+import io.github.pylonmc.rebar.item.RebarItemSchema
 import io.github.pylonmc.rebar.nms.entity.BlockTextureEntityImpl
 import io.github.pylonmc.rebar.nms.inventory.KeyedContainerListener
 import io.github.pylonmc.rebar.nms.packet.PlayerPacketHandler
@@ -17,6 +18,8 @@ import io.github.pylonmc.rebar.nms.recipe.HandlerRecipeBookClick
 import io.github.pylonmc.rebar.nms.recipe.RecipeMapper
 import io.github.pylonmc.rebar.util.position.BlockPosition
 import io.papermc.paper.adventure.PaperAdventure
+import io.papermc.paper.datacomponent.DataComponentType
+import io.papermc.paper.datacomponent.PaperDataComponentType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.kyori.adventure.text.Component
@@ -267,14 +270,15 @@ object NmsAccessorImpl : NmsAccessor {
         if (idEnd == -1) idEnd = input.length
 
         val typeString = input.substring(0, idEnd)
+        val data = input.substring(idEnd)
         val type = ItemTypeWrapper(NamespacedKey.fromString(typeString) ?: throw IllegalArgumentException("Could not find item $typeString"))
         if (type is ItemTypeWrapper.Rebar) {
-            input = "minecraft:air" + input.substring(idEnd)
+            input = "minecraft:air$data"
         }
 
         try {
-            val reader = if (input.isBlank()) null else StringReader(input)
-            val itemInput = if (input.isBlank()) null else ItemParser(CraftRegistry.getMinecraftRegistry()).parse(reader!!);
+            val reader = if (data.isBlank()) null else StringReader(input)
+            val itemInput = if (data.isBlank()) null else ItemParser(CraftRegistry.getMinecraftRegistry()).parse(reader!!);
             if (reader != null && reader.canRead()) {
                 throw IllegalArgumentException("Trailing input found when parsing ItemStack: " + reader.remaining);
             } else {
@@ -335,5 +339,21 @@ object NmsAccessorImpl : NmsAccessor {
         if (finalize && anyRemoved) {
             recipeManager.finalizeRecipeLoading()
         }
+    }
+
+    override fun getOverriddenTypes(itemStack: ItemStack): List<DataComponentType> {
+        val schema = RebarItemSchema.fromStack(itemStack)
+        val nmsStack = (itemStack as CraftItemStack).handle
+        if (schema != null) {
+            val template = schema.getOriginalTemplate()
+            val nmsTemplate = (template as CraftItemStack).handle
+            val types = mutableListOf<DataComponentType>()
+            for (type in nmsTemplate.components.keySet()) {
+                if (nmsTemplate.get(type) != nmsStack.get(type)) {
+                    types.add(PaperDataComponentType.minecraftToBukkit(type))
+                }
+            }
+        }
+        return nmsStack.componentsPatch.entrySet().map { PaperDataComponentType.minecraftToBukkit(it.key) }
     }
 }

--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/recipe/RecipeMapper.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/recipe/RecipeMapper.kt
@@ -1,0 +1,205 @@
+package io.github.pylonmc.rebar.nms.recipe
+
+import net.minecraft.core.registries.Registries
+import net.minecraft.world.item.crafting.AbstractCookingRecipe
+import net.minecraft.world.item.crafting.CampfireCookingRecipe
+import net.minecraft.world.item.crafting.CraftingRecipe
+import net.minecraft.world.item.crafting.RecipeHolder
+import net.minecraft.world.item.crafting.ShapedRecipePattern
+import net.minecraft.world.item.crafting.SmeltingRecipe
+import net.minecraft.world.item.crafting.StonecutterRecipe
+import org.bukkit.craftbukkit.CraftServer
+import org.bukkit.craftbukkit.inventory.CraftItemStack
+import org.bukkit.craftbukkit.inventory.CraftRecipe
+import org.bukkit.craftbukkit.inventory.trim.CraftTrimPattern
+import org.bukkit.craftbukkit.util.CraftNamespacedKey
+import org.bukkit.inventory.BlastingRecipe
+import org.bukkit.inventory.CampfireRecipe
+import org.bukkit.inventory.FurnaceRecipe
+import org.bukkit.inventory.Recipe
+import org.bukkit.inventory.ShapedRecipe
+import org.bukkit.inventory.ShapelessRecipe
+import org.bukkit.inventory.SmithingTransformRecipe
+import org.bukkit.inventory.SmithingTrimRecipe
+import org.bukkit.inventory.SmokingRecipe
+import org.bukkit.inventory.StonecuttingRecipe
+import org.bukkit.inventory.TransmuteRecipe
+import java.util.Objects
+import net.minecraft.world.item.crafting.BlastingRecipe as NmsBlastingRecipe
+import net.minecraft.world.item.crafting.Recipe as NmsRecipe
+import net.minecraft.world.item.crafting.ShapedRecipe as NmsShapedRecipe
+import net.minecraft.world.item.crafting.ShapelessRecipe as NmsShapelessRecipe
+import net.minecraft.world.item.crafting.SmithingTransformRecipe as NmsSmithingTransformRecipe
+import net.minecraft.world.item.crafting.SmithingTrimRecipe as NmsSmithingTrimRecipe
+import net.minecraft.world.item.crafting.SmokingRecipe as NmsSmokingRecipe
+import net.minecraft.world.item.crafting.TransmuteRecipe as NmsTransmuteRecipe
+
+/**
+ * Handles the conversion of bukkit recipes to nms recipes
+ * This has to be done manually because any existing conversion will individually
+ * convert and automatically register the recipe to the nms recipe manager and reload it.
+ *
+ * This is a problem because reloading the recipe manager is an expensive operation and
+ * doing it for every single recipe will cause a lot of lag.
+ *
+ * By manually converting the recipes we can register them all at once and reload
+ * the recipe manager only once saving up a LOT of tick time.
+ *
+ * Reference [CraftServer.addRecipe] to keep this up to date w/ version changes
+ */
+object RecipeMapper {
+    fun convertBukkitRecipe(recipe: Recipe): RecipeHolder<NmsRecipe<*>> {
+        val nmsRecipe = when (recipe) {
+            is ShapedRecipe -> convertShapedRecipe(recipe)
+            is ShapelessRecipe -> convertShapelessRecipe(recipe)
+            is FurnaceRecipe -> convertFurnaceRecipe(recipe)
+            is BlastingRecipe -> convertBlastingRecipe(recipe)
+            is CampfireRecipe -> convertCampfireRecipe(recipe)
+            is SmokingRecipe -> convertSmokingRecipe(recipe)
+            is StonecuttingRecipe -> convertStonecuttingRecipe(recipe)
+            is SmithingTransformRecipe -> convertSmithingTransformRecipe(recipe)
+            is SmithingTrimRecipe -> convertSmithingTrimRecipe(recipe)
+            is TransmuteRecipe -> convertTransmuteRecipe(recipe)
+            else -> {
+                throw IllegalArgumentException("Unknown recipe type ${recipe.javaClass.canonicalName}, cannot convert to NMS type")
+            }
+        }
+        return RecipeHolder(CraftNamespacedKey.toResourceKey(Registries.RECIPE, recipe.key), nmsRecipe)
+    }
+
+    private fun commonInfo() = NmsRecipe.CommonInfo(true)
+
+    private fun convertShapedRecipe(recipe: ShapedRecipe): NmsRecipe<*> {
+        val ingredients = recipe.choiceMap.filterValues(Objects::nonNull)
+            .mapValues { CraftRecipe.toIngredient(it.value, false) }
+        val shape = recipe.shape
+        for (i in shape.indices) {
+            val row = shape[i]
+            shape[i] = row.toCharArray().map { if (it in ingredients) it else ' ' }.joinToString("")
+        }
+        return NmsShapedRecipe(
+            commonInfo(),
+            CraftingRecipe.CraftingBookInfo(
+                CraftRecipe.getCategory(recipe.category),
+                recipe.group
+            ),
+            ShapedRecipePattern.of(ingredients, *shape),
+            CraftItemStack.asTemplate(recipe.result)
+        )
+    }
+
+    private fun convertShapelessRecipe(recipe: ShapelessRecipe): NmsRecipe<*> {
+        val ingredients = recipe.choiceList.map { CraftRecipe.toIngredient(it, false) }
+        return NmsShapelessRecipe(
+            commonInfo(),
+            CraftingRecipe.CraftingBookInfo(
+                CraftRecipe.getCategory(recipe.category),
+                recipe.group
+            ),
+            CraftItemStack.asTemplate(recipe.result),
+            ingredients
+        )
+    }
+
+    private fun convertFurnaceRecipe(recipe: FurnaceRecipe): NmsRecipe<*> {
+        return SmeltingRecipe(
+            commonInfo(),
+            AbstractCookingRecipe.CookingBookInfo(
+                CraftRecipe.getCategory(recipe.category),
+                recipe.group
+            ),
+            CraftRecipe.toIngredient(recipe.inputChoice, true),
+            CraftItemStack.asTemplate(recipe.result),
+            recipe.experience,
+            recipe.cookingTime
+        )
+    }
+
+    private fun convertBlastingRecipe(recipe: BlastingRecipe): NmsRecipe<*> {
+        return NmsBlastingRecipe(
+            commonInfo(),
+            AbstractCookingRecipe.CookingBookInfo(
+                CraftRecipe.getCategory(recipe.category),
+                recipe.group
+            ),
+            CraftRecipe.toIngredient(recipe.inputChoice, true),
+            CraftItemStack.asTemplate(recipe.result),
+            recipe.experience,
+            recipe.cookingTime
+        )
+    }
+
+    private fun convertCampfireRecipe(recipe: CampfireRecipe): NmsRecipe<*> {
+        return CampfireCookingRecipe(
+            commonInfo(),
+            AbstractCookingRecipe.CookingBookInfo(
+                CraftRecipe.getCategory(recipe.category),
+                recipe.group
+            ),
+            CraftRecipe.toIngredient(recipe.inputChoice, true),
+            CraftItemStack.asTemplate(recipe.result),
+            recipe.experience,
+            recipe.cookingTime
+        )
+    }
+
+    private fun convertSmokingRecipe(recipe: SmokingRecipe): NmsRecipe<*> {
+        return NmsSmokingRecipe(
+            commonInfo(),
+            AbstractCookingRecipe.CookingBookInfo(
+                CraftRecipe.getCategory(recipe.category),
+                recipe.group
+            ),
+            CraftRecipe.toIngredient(recipe.inputChoice, true),
+            CraftItemStack.asTemplate(recipe.result),
+            recipe.experience,
+            recipe.cookingTime
+        )
+    }
+
+    private fun convertStonecuttingRecipe(recipe: StonecuttingRecipe): NmsRecipe<*> {
+        return StonecutterRecipe(
+            commonInfo(),
+            CraftRecipe.toIngredient(recipe.inputChoice, true),
+            CraftItemStack.asTemplate(recipe.result)
+        )
+    }
+
+    private fun convertSmithingTransformRecipe(recipe: SmithingTransformRecipe): NmsRecipe<*> {
+        return NmsSmithingTransformRecipe(
+            commonInfo(),
+            CraftRecipe.toPossibleIngredient(recipe.template, false),
+            CraftRecipe.toIngredient(recipe.base, false),
+            CraftRecipe.toPossibleIngredient(recipe.addition, false),
+            CraftItemStack.asTemplate(recipe.result),
+            recipe.willCopyDataComponents()
+        )
+    }
+
+    private fun convertSmithingTrimRecipe(recipe: SmithingTrimRecipe): NmsRecipe<*> {
+        return NmsSmithingTrimRecipe(
+            commonInfo(),
+            CraftRecipe.toIngredient(recipe.template, false),
+            CraftRecipe.toIngredient(recipe.base, false),
+            CraftRecipe.toIngredient(recipe.addition, false),
+            CraftTrimPattern.bukkitToMinecraftHolder(recipe.trimPattern),
+            recipe.willCopyDataComponents()
+        )
+    }
+
+    private fun convertTransmuteRecipe(recipe: TransmuteRecipe): NmsRecipe<*> {
+        return NmsTransmuteRecipe(
+            commonInfo(),
+            CraftingRecipe.CraftingBookInfo(
+                CraftRecipe.getCategory(recipe.category),
+                recipe.group
+            ),
+            CraftRecipe.toIngredient(recipe.input, true),
+            CraftRecipe.toIngredient(recipe.material, true),
+            NmsTransmuteRecipe.DEFAULT_MATERIAL_COUNT,
+            CraftItemStack.asTemplate(recipe.result),
+            false
+        )
+    }
+
+}

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/Rebar.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/Rebar.kt
@@ -41,6 +41,7 @@ import io.github.pylonmc.rebar.recipe.RecipeType
 import io.github.pylonmc.rebar.registry.RebarRegistry
 import io.github.pylonmc.rebar.util.delayTicks
 import io.github.pylonmc.rebar.item.interfaces.*
+import io.github.pylonmc.rebar.nms.NmsAccessor
 import io.github.pylonmc.rebar.util.mergeResource
 import io.github.pylonmc.rebar.waila.Waila
 import io.github.pylonmc.rebar.waila.WailaPlaceholders
@@ -350,6 +351,7 @@ object Rebar : JavaPlugin(), RebarAddon {
             }
         }
 
+        NmsAccessor.processRecipeQueue()
         val end = System.currentTimeMillis()
         logger.info("Loaded recipes in ${(end - start) / 1000.0}s")
         RebarConfigurableRecipesLoadedEvent().callEvent()

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/config/adapter/ConfigAdapter.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/config/adapter/ConfigAdapter.kt
@@ -1,7 +1,7 @@
 package io.github.pylonmc.rebar.config.adapter
 
-import io.github.pylonmc.rebar.datatypes.RebarSerializers.KEYED
 import io.github.pylonmc.rebar.fluid.tags.FluidTemperature
+import io.github.pylonmc.rebar.item.ItemTypeWrapper
 import io.github.pylonmc.rebar.registry.RebarRegistry
 import io.github.pylonmc.rebar.util.RandomizedSound
 import net.kyori.adventure.sound.Sound
@@ -50,6 +50,7 @@ interface ConfigAdapter<T> {
         @JvmField val KEYED = KeyedConfigAdapter
         @JvmField val NAMESPACED_KEY = ConfigAdapter { NamespacedKey.fromString(STRING.convert(it))!! }
         @JvmField val MATERIAL = KEYED.fromRegistry(Registry.MATERIAL)
+        @JvmField val ITEM_TYPE_WRAPPER = KEYED.fromGetter { ItemTypeWrapper(it) }
         @JvmField val ITEM_STACK = ItemStackConfigAdapter
         @JvmField val BLOCK_DATA = ConfigAdapter { Bukkit.createBlockData(STRING.convert(it)) }
 
@@ -133,6 +134,7 @@ interface ConfigAdapter<T> {
         @JvmField val RECIPE_INPUT = RecipeInputConfigAdapter
         @JvmField val RECIPE_INPUT_ITEM = RecipeInputItemAdapter
         @JvmField val RECIPE_INPUT_FLUID = RecipeInputFluidAdapter
+        @JvmField val RECIPE_CHOICE = RecipeChoiceConfigAdapter
         @JvmField val ITEM_TAG = ItemTagConfigAdapter
         @JvmField val WEIGHTED_SET = WeightedSetConfigAdapter
         @JvmField val CULLING_PRESET = CullingPresetConfigAdapter

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/config/adapter/KeyedConfigAdapter.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/config/adapter/KeyedConfigAdapter.kt
@@ -16,17 +16,17 @@ abstract class KeyedConfigAdapter<T : Keyed> : ConfigAdapter<T> {
     companion object {
 
         @JvmStatic
-        fun <T : Keyed> fromGetter(clazz: Class<T>, fromKey: (NamespacedKey) -> T): ConfigAdapter<T> =
+        fun <T : Keyed> fromGetter(clazz: Class<T>, getter: (NamespacedKey) -> T): ConfigAdapter<T> =
             object : KeyedConfigAdapter<T>() {
                 override val type = clazz
-                override fun fromKey(key: NamespacedKey): T = fromKey(key)
+                override fun fromKey(key: NamespacedKey): T = getter(key)
             }
 
         @JvmSynthetic
-        inline fun <reified T : Keyed> fromGetter(crossinline fromKey: (NamespacedKey) -> T): ConfigAdapter<T> =
+        inline fun <reified T : Keyed> fromGetter(crossinline getter: (NamespacedKey) -> T): ConfigAdapter<T> =
             object : KeyedConfigAdapter<T>() {
                 override val type = T::class.java
-                override fun fromKey(key: NamespacedKey): T = fromKey(key)
+                override fun fromKey(key: NamespacedKey): T = getter(key)
             }
 
         @JvmStatic

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/config/adapter/RecipeChoiceConfigAdapter.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/config/adapter/RecipeChoiceConfigAdapter.kt
@@ -1,0 +1,59 @@
+package io.github.pylonmc.rebar.config.adapter
+
+import io.github.pylonmc.rebar.item.ItemTypeWrapper
+import org.bukkit.configuration.ConfigurationSection
+import org.bukkit.inventory.RecipeChoice
+
+object RecipeChoiceConfigAdapter: ConfigAdapter<RecipeChoice> {
+    override val type = RecipeChoice::class.java
+
+    override fun convert(value: Any): RecipeChoice {
+        return when (value) {
+            is ConfigurationSection, is Map<*, *> -> convert(
+                MapConfigAdapter.STRING_TO_ANY.convert(value).toList().single()
+            )
+
+            is Pair<*, *> -> {
+                val ingredient = ConfigAdapter.STRING.convert(value.first!!)
+                val amount = ConfigAdapter.INTEGER.convert(value.second!!)
+                if (ingredient.startsWith("#")) {
+                    val tag = ConfigAdapter.ITEM_TAG.convert(value.first!!)
+                    val exact = amount > 1 || tag.values.any { it is ItemTypeWrapper.Rebar }
+                    if (exact) {
+                        RecipeChoice.ExactChoice(tag.values.map { it.createItemStack(amount) })
+                    } else {
+                        RecipeChoice.MaterialChoice(tag.values.map { (it as ItemTypeWrapper.Vanilla).material })
+                    }
+                } else if (ingredient.contains("[")) {
+                    val stack = ConfigAdapter.ITEM_STACK.convert(value)
+                    stack.amount = amount
+                    RecipeChoice.ExactChoice(stack)
+                } else {
+                    val type = ConfigAdapter.ITEM_TYPE_WRAPPER.convert(ingredient)
+                    if (amount > 1 || type is ItemTypeWrapper.Rebar) {
+                        RecipeChoice.ExactChoice(type.createItemStack(amount))
+                    } else {
+                        RecipeChoice.MaterialChoice((type as ItemTypeWrapper.Vanilla).material)
+                    }
+                }
+            }
+
+            is String -> {
+                if (value.startsWith("#")) {
+                    convert(value to 1)
+                } else if (value.contains("[")) {
+                    val stack = ConfigAdapter.ITEM_STACK.convert(value)
+                    RecipeChoice.ExactChoice(stack)
+                } else {
+                    val type = ConfigAdapter.ITEM_TYPE_WRAPPER.convert(value)
+                    if (type is ItemTypeWrapper.Rebar) {
+                        RecipeChoice.ExactChoice(type.createItemStack())
+                    } else {
+                        RecipeChoice.MaterialChoice((type as ItemTypeWrapper.Vanilla).material)
+                    }
+                }
+            }
+            else -> throw IllegalArgumentException("Cannot convert $value to recipe choice")
+        }
+    }
+}

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/item/RebarItemSchema.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/item/RebarItemSchema.kt
@@ -50,7 +50,7 @@ class RebarItemSchema @JvmOverloads internal constructor(
      * Return's a clone of the [template] [ItemStack]
      */
     @JvmOverloads
-    fun getItemStack(count: Int = 1): ItemStack = template.asQuantity(min(count, template.maxStackSize))
+    fun getItemStack(count: Int = 1): ItemStack = if (count == 1) template.asOne() else template.asQuantity(min(count, template.maxStackSize))
 
     /**
      * Return's a new instance of the [RebarItem] from the [itemClass] using a copy of the [template] [ItemStack]

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessor.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessor.kt
@@ -1,10 +1,13 @@
 package io.github.pylonmc.rebar.nms
 
 import com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent
+import io.github.pylonmc.rebar.Rebar
 import io.github.pylonmc.rebar.block.RebarBlock
 import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity
 import io.github.pylonmc.rebar.i18n.PlayerTranslationHandler
+import io.github.pylonmc.rebar.util.delayTicks
 import io.github.pylonmc.rebar.util.position.BlockPosition
+import kotlinx.coroutines.launch
 import net.kyori.adventure.text.Component
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
@@ -19,6 +22,7 @@ import org.bukkit.inventory.Inventory
 import org.bukkit.inventory.InventoryView
 import org.bukkit.inventory.ItemFactory
 import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.Recipe
 import org.bukkit.persistence.PersistentDataContainer
 import org.jetbrains.annotations.ApiStatus
 import java.util.UUID
@@ -116,9 +120,50 @@ interface NmsAccessor {
      */
     fun simulateInteract(player: Player, itemStack: ItemStack, hand: EquipmentSlot, block: Block?, blockFace: BlockFace?)
 
+    fun hasRecipe(key: NamespacedKey): Boolean
+
+    fun registerRecipes(recipes: Iterable<Recipe>, finalize: Boolean)
+
+    fun unregisterRecipes(recipes: Iterable<NamespacedKey>, finalize: Boolean)
+
     companion object {
         val instance = Class.forName("io.github.pylonmc.rebar.nms.NmsAccessorImpl")
             .getDeclaredField("INSTANCE")
             .get(null) as NmsAccessor
+
+        private val recipeRegisterQueue = mutableSetOf<Recipe>()
+        private val recipeUnregisterQueue = mutableSetOf<NamespacedKey>()
+
+        private val registerRecipeJob = Rebar.scope.launch {
+            while (true) {
+                processRecipeQueue()
+                delayTicks(1)
+            }
+        }
+
+        @JvmStatic
+        fun queueRegisterRecipe(recipe: Recipe) {
+            recipeRegisterQueue.add(recipe)
+        }
+
+        @JvmStatic
+        fun queueUnregisterRecipe(recipeKey: NamespacedKey) {
+            recipeUnregisterQueue.add(recipeKey)
+        }
+
+        @JvmStatic
+        fun processRecipeQueue() {
+            if (recipeUnregisterQueue.isNotEmpty()) {
+                val unregistering = recipeUnregisterQueue.toSet()
+                recipeUnregisterQueue.clear()
+                instance.unregisterRecipes(unregistering, false)
+            }
+
+            if (recipeRegisterQueue.isNotEmpty()) {
+                val registering = recipeRegisterQueue.toSet()
+                recipeRegisterQueue.clear()
+                instance.registerRecipes(registering, true)
+            }
+        }
     }
 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessor.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessor.kt
@@ -7,6 +7,7 @@ import io.github.pylonmc.rebar.entity.packet.BlockTextureEntity
 import io.github.pylonmc.rebar.i18n.PlayerTranslationHandler
 import io.github.pylonmc.rebar.util.delayTicks
 import io.github.pylonmc.rebar.util.position.BlockPosition
+import io.papermc.paper.datacomponent.DataComponentType
 import kotlinx.coroutines.launch
 import net.kyori.adventure.text.Component
 import org.bukkit.Material
@@ -125,6 +126,8 @@ interface NmsAccessor {
     fun registerRecipes(recipes: Iterable<Recipe>, finalize: Boolean)
 
     fun unregisterRecipes(recipes: Iterable<NamespacedKey>, finalize: Boolean)
+
+    fun getOverriddenTypes(itemStack: ItemStack): List<DataComponentType>
 
     companion object {
         val instance = Class.forName("io.github.pylonmc.rebar.nms.NmsAccessorImpl")

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/Cooking.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/Cooking.kt
@@ -75,9 +75,9 @@ private inline fun <T : CookingRecipe<T>> loadCookingRecipe(
 ): T {
     val cookingTime = config.get("cookingtime", ConfigAdapter.INTEGER, defaultCookingTime)
     val experience = config.get("experience", ConfigAdapter.FLOAT, 0f)
-    val ingredient = config.getOrThrow("ingredient", ConfigAdapter.RECIPE_INPUT_ITEM)
+    val ingredient = config.getOrThrow("ingredient", ConfigAdapter.RECIPE_CHOICE)
     val result = config.getOrThrow("result", ConfigAdapter.ITEM_STACK)
-    val recipe = cons(key, result, ingredient.asRecipeChoice(), experience, cookingTime)
+    val recipe = cons(key, result, ingredient, experience, cookingTime)
     config.get("category", ConfigAdapter.ENUM.from<CookingBookCategory>())?.let { recipe.category = it }
     config.get("group", ConfigAdapter.STRING)?.let { recipe.group = it }
     return recipe

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/Crafting.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/Crafting.kt
@@ -20,12 +20,13 @@ sealed class CraftingRecipeWrapper(val craftingRecipe: CraftingRecipe) : Vanilla
 }
 
 class ShapedRecipeWrapper(override val recipe: ShapedRecipe) : CraftingRecipeWrapper(recipe) {
-    override val inputs: List<RecipeInput> =
+    override val inputs: List<RecipeInput> by lazy {
         recipe.shape
             .flatMap { it.asIterable() }
             .mapNotNull {
                 recipe.choiceMap[it]?.asRecipeInput()
             }
+    }
 
     override fun display(): Gui {
         val gui = Gui.builder()
@@ -109,14 +110,14 @@ object ShapedRecipeType : VanillaRecipeType<ShapedRecipeWrapper>("crafting_shape
     fun addRecipe(recipe: ShapedRecipe) = super.addRecipe(ShapedRecipeWrapper(recipe))
 
     override fun loadRecipe(key: NamespacedKey, section: ConfigSection): ShapedRecipeWrapper {
-        val ingredientKey = section.getOrThrow("key", ConfigAdapter.MAP.from(ConfigAdapter.CHAR, ConfigAdapter.RECIPE_INPUT_ITEM))
+        val ingredientKey = section.getOrThrow("key", ConfigAdapter.MAP.from(ConfigAdapter.CHAR, ConfigAdapter.RECIPE_CHOICE))
         val pattern = section.getOrThrow("pattern", ConfigAdapter.LIST.from(ConfigAdapter.STRING))
         val result = section.getOrThrow("result", ConfigAdapter.ITEM_STACK)
 
         val recipe = ShapedRecipe(key, result)
         recipe.shape(*pattern.toTypedArray())
         for ((character, item) in ingredientKey) {
-            recipe.setIngredient(character, item.asRecipeChoice())
+            recipe.setIngredient(character, item)
         }
         section.get("category", CRAFTING_BOOK_CATEGORY_ADAPTER)?.let { recipe.category = it }
         section.get("group", ConfigAdapter.STRING)?.let { recipe.group = it }
@@ -132,12 +133,12 @@ object ShapelessRecipeType : VanillaRecipeType<ShapelessRecipeWrapper>("crafting
     fun addRecipe(recipe: ShapelessRecipe) = super.addRecipe(ShapelessRecipeWrapper(recipe))
 
     override fun loadRecipe(key: NamespacedKey, section: ConfigSection): ShapelessRecipeWrapper {
-        val ingredients = section.getOrThrow("ingredients", ConfigAdapter.LIST.from(ConfigAdapter.RECIPE_INPUT_ITEM))
+        val ingredients = section.getOrThrow("ingredients", ConfigAdapter.LIST.from(ConfigAdapter.RECIPE_CHOICE))
         val result = section.getOrThrow("result", ConfigAdapter.ITEM_STACK)
 
         val recipe = ShapelessRecipe(key, result)
         for (ingredient in ingredients) {
-            recipe.addIngredient(ingredient.asRecipeChoice())
+            recipe.addIngredient(ingredient)
         }
         section.get("category", CRAFTING_BOOK_CATEGORY_ADAPTER)?.let { recipe.category = it }
         section.get("group", ConfigAdapter.STRING)?.let { recipe.group = it }
@@ -153,12 +154,12 @@ object TransmuteRecipeType : VanillaRecipeType<TransmuteRecipeWrapper>("crafting
     fun addRecipe(recipe: TransmuteRecipe) = super.addRecipe(TransmuteRecipeWrapper(recipe))
 
     override fun loadRecipe(key: NamespacedKey, section: ConfigSection): TransmuteRecipeWrapper {
-        val input = section.getOrThrow("input", ConfigAdapter.RECIPE_INPUT_ITEM)
-        val material = section.getOrThrow("material", ConfigAdapter.RECIPE_INPUT_ITEM)
+        val input = section.getOrThrow("input", ConfigAdapter.RECIPE_CHOICE)
+        val material = section.getOrThrow("material", ConfigAdapter.RECIPE_CHOICE)
         val result = section.getOrThrow("result", ConfigAdapter.MATERIAL)
         val category = section.get("category", CRAFTING_BOOK_CATEGORY_ADAPTER, CraftingBookCategory.MISC)
         val group = section.get("group", ConfigAdapter.STRING, "")
-        val recipe = TransmuteRecipe(key, result, input.asRecipeChoice(), material.asRecipeChoice())
+        val recipe = TransmuteRecipe(key, result, input, material)
         recipe.category = category
         recipe.group = group
         return TransmuteRecipeWrapper(recipe)

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/Smithing.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/Smithing.kt
@@ -53,17 +53,17 @@ object SmithingTransformRecipeType : VanillaRecipeType<SmithingTransformRecipeWr
     fun addRecipe(recipe: SmithingTransformRecipe) = super.addRecipe(SmithingTransformRecipeWrapper(recipe))
 
     override fun loadRecipe(key: NamespacedKey, section: ConfigSection): SmithingTransformRecipeWrapper {
-        val template = section.getOrThrow("template", ConfigAdapter.RECIPE_INPUT_ITEM)
-        val base = section.getOrThrow("base", ConfigAdapter.RECIPE_INPUT_ITEM)
-        val addition = section.getOrThrow("addition", ConfigAdapter.RECIPE_INPUT_ITEM)
+        val template = section.getOrThrow("template", ConfigAdapter.RECIPE_CHOICE)
+        val base = section.getOrThrow("base", ConfigAdapter.RECIPE_CHOICE)
+        val addition = section.getOrThrow("addition", ConfigAdapter.RECIPE_CHOICE)
         val result = section.getOrThrow("result", ConfigAdapter.ITEM_STACK)
         return SmithingTransformRecipeWrapper(
             SmithingTransformRecipe(
                 key,
                 result,
-                template.asRecipeChoice(),
-                base.asRecipeChoice(),
-                addition.asRecipeChoice()
+                template,
+                base,
+                addition
             )
         )
     }
@@ -82,15 +82,15 @@ object SmithingTrimRecipeType : VanillaRecipeType<SmithingTrimRecipeWrapper>("sm
 
     override fun loadRecipe(key: NamespacedKey, section: ConfigSection): SmithingTrimRecipeWrapper {
         val pattern = section.getOrThrow("pattern", TRIM_PATTERN_ADAPTER)
-        val template = section.getOrThrow("template", ConfigAdapter.RECIPE_INPUT_ITEM)
-        val base = section.getOrThrow("base", ConfigAdapter.RECIPE_INPUT_ITEM)
-        val addition = section.getOrThrow("addition", ConfigAdapter.RECIPE_INPUT_ITEM)
+        val template = section.getOrThrow("template", ConfigAdapter.RECIPE_CHOICE)
+        val base = section.getOrThrow("base", ConfigAdapter.RECIPE_CHOICE)
+        val addition = section.getOrThrow("addition", ConfigAdapter.RECIPE_CHOICE)
         return SmithingTrimRecipeWrapper(
             SmithingTrimRecipe(
                 key,
-                template.asRecipeChoice(),
-                base.asRecipeChoice(),
-                addition.asRecipeChoice(),
+                template,
+                base,
+                addition,
                 pattern
             )
         )

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/VanillaRecipeType.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/VanillaRecipeType.kt
@@ -2,6 +2,7 @@ package io.github.pylonmc.rebar.recipe.vanilla
 
 import io.github.pylonmc.rebar.Rebar
 import io.github.pylonmc.rebar.item.ItemTypeWrapper
+import io.github.pylonmc.rebar.nms.NmsAccessor
 import io.github.pylonmc.rebar.recipe.ConfigurableRecipeType
 import io.github.pylonmc.rebar.recipe.RebarRecipe
 import io.github.pylonmc.rebar.recipe.RecipeInput
@@ -30,10 +31,10 @@ sealed class VanillaRecipeType<T : VanillaRecipeWrapper>(key: String) :
 
     override fun addRecipe(recipe: T) {
         super.addRecipe(recipe)
-        if (Bukkit.getRecipe(recipe.key) != null) {
-            Bukkit.removeRecipe(recipe.key)
+        if (NmsAccessor.instance.hasRecipe(recipe.key)) {
+            NmsAccessor.queueUnregisterRecipe(recipe.key)
         }
-        Bukkit.addRecipe(recipe.recipe)
+        NmsAccessor.queueRegisterRecipe(recipe.recipe)
     }
 
     @JvmSynthetic
@@ -44,7 +45,7 @@ sealed class VanillaRecipeType<T : VanillaRecipeWrapper>(key: String) :
 
     override fun removeRecipe(recipe: NamespacedKey) {
         super.removeRecipe(recipe)
-        Bukkit.removeRecipe(recipe)
+        NmsAccessor.queueUnregisterRecipe(recipe)
     }
 
     companion object {

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/VanillaRecipeType.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/vanilla/VanillaRecipeType.kt
@@ -71,11 +71,6 @@ internal fun RecipeChoice.asRecipeInput(): RecipeInput {
     }
 }
 
-@JvmSynthetic
-internal fun RecipeInput.Item.asRecipeChoice(): RecipeChoice {
-    return RecipeChoice.ExactChoice(representativeItems.mapTo(mutableListOf()) { it.clone() })
-}
-
 @get:JvmSynthetic
 val CookingRecipe<*>.recipeType: RecipeType<*>?
     get() = when (this) {

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/util/RebarUtils.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/util/RebarUtils.kt
@@ -18,6 +18,7 @@ import io.github.pylonmc.rebar.nms.NmsAccessor
 import io.github.pylonmc.rebar.registry.RebarRegistry
 import io.github.pylonmc.rebar.util.position.BlockPosition
 import io.papermc.paper.datacomponent.DataComponentType
+import io.papermc.paper.datacomponent.DataComponentTypes
 import io.papermc.paper.registry.keys.tags.BlockTypeTagKeys
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -733,18 +734,7 @@ fun ItemStack.setComponents(components: Map<DataComponentType, Any?>) {
 }
 
 fun ItemStack.overriddenDataTypes(): List<DataComponentType> {
-    val schema = RebarItemSchema.fromStack(this)
-    if (schema != null) {
-        val template = schema.getOriginalTemplate()
-        return dataTypes.filter {
-            return@filter when (it) {
-                is DataComponentType.NonValued -> hasData(it) != template.hasData(it)
-                is DataComponentType.Valued<*> -> getData(it) != template.getData(it)
-                else -> false
-            }
-        }
-    }
-    return dataTypes.filter { isDataOverridden(it) }
+    return NmsAccessor.instance.getOverriddenTypes(this)
 }
 
 const val FLUID_EPSILON = 1.0e-6

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/recipe/CraftingTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/recipe/CraftingTest.java
@@ -1,5 +1,6 @@
 package io.github.pylonmc.rebar.test.test.recipe;
 
+import io.github.pylonmc.rebar.nms.NmsAccessor;
 import io.github.pylonmc.rebar.recipe.RecipeType;
 import io.github.pylonmc.rebar.test.RebarTest;
 import io.github.pylonmc.rebar.test.base.SyncTest;
@@ -40,6 +41,7 @@ public class CraftingTest extends SyncTest {
                     normalStick, stickyStick, normalStick,
                     nothing, normalStick, nothing
             };
+            NmsAccessor.processRecipeQueue();
             assertThat(Bukkit.craftItem(crafting, RebarTest.testWorld))
                     .isEqualTo(diamond);
         }
@@ -55,6 +57,7 @@ public class CraftingTest extends SyncTest {
             Arrays.fill(crafting, nothing);
             crafting[0] = stickyStick;
             crafting[1] = diamond;
+            NmsAccessor.processRecipeQueue();
             assertThat(Bukkit.craftItem(crafting, RebarTest.testWorld))
                     .isEqualTo(normalStick);
         }
@@ -76,6 +79,7 @@ public class CraftingTest extends SyncTest {
                     normalStick, diamond, normalStick,
                     nothing, normalStick, nothing
             };
+            NmsAccessor.processRecipeQueue();
             assertThat(Bukkit.craftItem(crafting, RebarTest.testWorld))
                     .isEqualTo(stickyStick);
         }


### PR DESCRIPTION
Bukkit will completely reload the NMS RecipeManager for every single recipe that is (un)registered, so when registering lots of recipes at once using the Bukkit methods, it does a LOT of unnecessary reloading, which gets exponentially slower with each recipe (un)registered. (This gets even worse when there are players online at the time of registration, though currently that does not apply to us as this happens while the server is starting & we do not reload recipes ever, however if we did it would be EVEN better as previously it would have to reload once per recipe to unregister and then once per recipe to re-register)

We can solve this problem by batching the recipes & registering them ourselves using NMS instead of going through Bukkit, allowing us to register/unregister anything necessary and only reload the RecipeManager one time.

Difference in recipe load time on my machine:
- Not Debugging: `0.611s` -> `0.219s`
- Debugging: `0.805s` -> `0.273s`

*I think that machines which have a longer recipe load time before batching will benefit even more proportionately than I do, but I need other people's numbers to back that up*

I also took some spark reports (not debugging) of only the recipe loading:
Before batching: https://spark.lucko.me/LPtzjd1uLt
After batching: https://spark.lucko.me/9n3gWagj8A

<img width="1142" height="374" alt="image" src="https://github.com/user-attachments/assets/bbb504a2-9279-4571-be54-b6d0201c40f6" />