### PR TITLE
Only ItemButton#of & FluidButton#of

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/guide/RebarGuide.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/guide/RebarGuide.kt
@@ -107,7 +107,7 @@ class RebarGuide(stack: ItemStack) : RebarItem(stack), InteractRebarItemHandler 
             rebarKey("fluids"),
             {
                 RebarRegistry.FLUIDS.filter { it.key !in hiddenFluids }
-                    .map { FluidButton(it) }
+                    .map { FluidButton.of(it) }
                     .toMutableList()
             }
         ) {}

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/button/FluidButton.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/button/FluidButton.kt
@@ -5,6 +5,7 @@ import io.github.pylonmc.rebar.guide.pages.fluid.FluidRecipesPage
 import io.github.pylonmc.rebar.guide.pages.fluid.FluidUsagesPage
 import io.github.pylonmc.rebar.i18n.RebarArgument
 import io.github.pylonmc.rebar.item.builder.ItemStackBuilder
+import io.github.pylonmc.rebar.recipe.FluidOrItem
 import io.github.pylonmc.rebar.recipe.RecipeInput
 import io.github.pylonmc.rebar.util.gui.unit.UnitFormat
 import io.papermc.paper.datacomponent.DataComponentTypes
@@ -15,6 +16,7 @@ import org.bukkit.entity.Player
 import org.bukkit.event.inventory.ClickType
 import xyz.xenondevs.invui.Click
 import xyz.xenondevs.invui.item.AbstractItem
+import xyz.xenondevs.invui.item.Item
 
 /**
  * Represents a fluid in the guide.
@@ -22,7 +24,7 @@ import xyz.xenondevs.invui.item.AbstractItem
  * @param fluids The list of fluids to display. If multiple fluids are supplied, the button automatically
  * cycles through all of them. You must supply at least one fluid
  */
-open class FluidButton(
+open class FluidButton private constructor(
     fluids: List<RebarFluid>,
 
     /**
@@ -33,23 +35,9 @@ open class FluidButton(
     /**
      * A function to apply to the button item after creating it.
      */
-    val preDisplayDecorator: (ItemStackBuilder) -> ItemStackBuilder
+    val preDisplayDecorator: Decorator
 
 ) : AbstractItem() {
-
-    /**
-     * @param fluids The list of fluids to display. If multiple fluids are supplied, the button
-     * cycles through them. You must supply at least one fluid
-     */
-    constructor(amount: Double?, vararg fluids: RebarFluid) : this(fluids.toList(), amount, { it })
-
-    /**
-     * @param fluids The list of fluids to display. If multiple fluids are supplied, the button
-     * cycles through them. You must supply at least one fluid
-     */
-    constructor(vararg fluids: RebarFluid) : this(null, *fluids)
-
-    constructor(input: RecipeInput.Fluid) : this(input.amountMillibuckets, *input.fluids.toTypedArray())
 
     val fluids = fluids.shuffled()
     val currentFluid: RebarFluid
@@ -97,5 +85,45 @@ open class FluidButton(
         } catch (e: Exception) {
             e.printStackTrace()
         }
+    }
+
+    companion object {
+        private typealias Decorator = (ItemStackBuilder) -> ItemStackBuilder
+
+        /**
+         * @param fluids The list of fluids to display. If multiple fluids are supplied, the button
+         * cycles through them. (if no fluids are provided, returns an empty item)
+         */
+        @JvmStatic
+        fun of(vararg fluids: RebarFluid?): Item = of(fluids.toList(), null)
+
+        /**
+         * @param fluids The list of fluids to display. If multiple fluids are supplied, the button
+         * cycles through them. (if no fluids are provided, returns an empty item)
+         */
+        @JvmStatic
+        fun of(amount: Double?, vararg fluids: RebarFluid?): Item = of(fluids.toList(), amount)
+
+        /**
+         * @param fluids The list of fluids to display. If multiple fluids are supplied, the button
+         * cycles through them. (if no fluids are provided, returns an empty item)
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun of(fluids: List<RebarFluid?>, amount: Double?, preDisplayDecorator: Decorator? = null): Item = if (fluids.filterNotNull().isEmpty()) {
+            EMPTY
+        } else {
+            FluidButton(fluids.filterNotNull(), amount, preDisplayDecorator ?: { it })
+        }
+
+        @JvmStatic
+        @JvmOverloads
+        fun of(input: RecipeInput.Fluid, preDisplayDecorator: Decorator? = null)
+            = of(input.fluids.toList(), input.amountMillibuckets, preDisplayDecorator)
+
+        @JvmStatic
+        @JvmOverloads
+        fun of(fluid: FluidOrItem.Fluid, preDisplayDecorator: Decorator? = null)
+            = FluidButton(listOf(fluid.fluid), fluid.amountMillibuckets, preDisplayDecorator ?: { it })
     }
 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/button/ItemButton.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/button/ItemButton.kt
@@ -35,26 +35,14 @@ import xyz.xenondevs.invui.item.ItemProvider
  * @param stacks The items to display. If multiple are provided, the button will automatically
  * cycle through all of them. You must supply at least one item
  */
-class ItemButton @JvmOverloads constructor(
+class ItemButton private constructor(
     stacks: List<ItemStack>,
 
     /**
      * A function to apply to the button item after creating it.
      */
-    val preDisplayDecorator: (ItemStack, Player) -> ItemStack = { stack, _ -> stack }
+    val preDisplayDecorator: Decorator = noDecorator
 ) : AbstractBoundItem() {
-
-    /**
-     * @param stacks The items to display. If multiple are provided, the button will automatically
-     * cycle through all of them. You must supply at least one item
-     */
-    constructor(vararg stacks: ItemStack) : this(stacks.toList())
-
-    /**
-     * @param stack The item to display
-     * @param preDisplayDecorator A function to apply to the button item after creating it
-     */
-    constructor(stack: ItemStack, preDisplayDecorator: (ItemStack, Player) -> ItemStack) : this(listOf(stack), preDisplayDecorator)
 
     val stacks = stacks.shuffled()
     val currentStack: ItemStack
@@ -204,6 +192,9 @@ class ItemButton @JvmOverloads constructor(
     }
 
     companion object {
+        private typealias Decorator = (ItemStack, Player) -> ItemStack
+        private val noDecorator: Decorator = { stack, _ -> stack }
+
         @Suppress("UnstableApiUsage")
         private fun getCheatItemStack(currentStack: ItemStack, click: Click): ItemStack {
             val itemSchema = RebarItemSchema.fromStack(currentStack)
@@ -225,21 +216,13 @@ class ItemButton @JvmOverloads constructor(
         }
 
         @JvmStatic
-        fun of(stack: ItemStack?): Item {
+        @JvmOverloads
+        fun of(stack: ItemStack?, preDisplayDecorator: Decorator? = null): Item {
             if (stack == null || stack.isEmpty) {
                 return EMPTY
             }
 
-            return ItemButton(stack)
-        }
-
-        @JvmStatic
-        fun of(stack: ItemStack?, preDisplayDecorator: (ItemStack, Player) -> ItemStack): Item {
-            if (stack == null || stack.isEmpty) {
-                return EMPTY
-            }
-
-            return ItemButton(listOf(stack), preDisplayDecorator)
+            return ItemButton(listOf(stack), preDisplayDecorator ?: noDecorator)
         }
 
         @JvmStatic
@@ -248,33 +231,29 @@ class ItemButton @JvmOverloads constructor(
                 return EMPTY
             }
 
-            return ItemButton(*input.representativeItems.toTypedArray())
+            return of(input.representativeItems.toList())
         }
 
         @JvmStatic
         fun of(choice: RecipeChoice?): Item = when (choice) {
-            is RecipeChoice.MaterialChoice -> ItemButton(choice.choices.map(::ItemStack))
-            is RecipeChoice.ExactChoice -> ItemButton(choice.choices)
+            is RecipeChoice.MaterialChoice -> of(choice.choices.map(ItemStack::of))
+            is RecipeChoice.ExactChoice -> of(choice.choices)
             else -> EMPTY
         }
 
         @JvmStatic @JvmOverloads
-        fun of(stacks: List<ItemStack>, preDisplayDecorator: (ItemStack, Player) -> ItemStack = { stack, _ -> stack })
-                = ItemButton(stacks, preDisplayDecorator)
-        /**
-         * @param stacks The items to display. If multiple are provided, the button will automatically
-         * cycle through all of them. You must supply at least one item
-         */
-        @JvmStatic
-        fun of(vararg stacks: ItemStack)
-                = ItemButton(stacks.toList())
+        fun of(stacks: List<ItemStack?>, preDisplayDecorator: Decorator? = null) = if (stacks.filterNotNull().isEmpty()) {
+            EMPTY
+        } else {
+            ItemButton(stacks.filterNotNull(), preDisplayDecorator ?: noDecorator)
+        }
 
         /**
-         * @param stack The item to display
-         * @param preDisplayDecorator A function to apply to the button item after creating it
+         * @param stacks The items to display. If multiple are provided, the button will automatically
+         * cycle through all of them. (if no items are provided, returns an empty item)
          */
         @JvmStatic
-        fun of(stack: ItemStack, preDisplayDecorator: (ItemStack, Player) -> ItemStack)
-                = ItemButton(stack, preDisplayDecorator)
+        @JvmOverloads
+        fun of(preDisplayDecorator: Decorator? = null, vararg stacks: ItemStack?) = of(stacks.toList(), preDisplayDecorator)
     }
 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/SearchItemsAndFluidsPage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/SearchItemsAndFluidsPage.kt
@@ -21,14 +21,14 @@ class SearchItemsAndFluidsPage : SearchPage(rebarKey("search")) {
         it.key !in RebarGuide.hiddenItems || (it.key in RebarGuide.adminOnlyItems && player.hasPermission("rebar.guide.cheat"))
     }.map { item ->
         val name = GlobalTranslator.render(Component.translatable("${item.key.namespace}.item.${item.key.key}.name"), player.locale())
-        ItemButton(item.getItemStack()) to name.plainText.lowercase(player.locale())
+        ItemButton.of(item.getItemStack()) to name.plainText.lowercase(player.locale())
     }.toMutableList()
 
     fun getFluidButtons(player: Player): MutableList<Pair<Item, String>> = RebarRegistry.FLUIDS.filter {
         it.key !in RebarGuide.hiddenFluids
     }.map { fluid ->
         val name = GlobalTranslator.render(Component.translatable("${fluid.key.namespace}.fluid.${fluid.key.key}"), player.locale())
-        FluidButton(fluid) to name.plainText.lowercase(player.locale())
+        FluidButton.of(fluid) to name.plainText.lowercase(player.locale())
     }.toMutableList()
 
     override fun getItemNamePairs(player: Player, search: String): List<Pair<Item, String>> {

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/base/SimpleStaticGuidePage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/base/SimpleStaticGuidePage.kt
@@ -39,7 +39,7 @@ open class SimpleStaticGuidePage @JvmOverloads constructor(
     open fun addPage(material: Material, page: GuidePage) = addButton(PageButton(material, page))
     open fun addPage(stack: ItemStack, page: GuidePage) = addButton(PageButton(stack.clone(), page))
     open fun addPage(builder: ItemStackBuilder, page: GuidePage) = addButton(PageButton(builder.build().clone(), page))
-    open fun addItem(item: ItemStack) = addButton(ItemButton(item))
-    open fun addFluid(fluid: RebarFluid) = addButton(FluidButton(fluid))
+    open fun addItem(item: ItemStack) = addButton(ItemButton.of(item))
+    open fun addFluid(fluid: RebarFluid) = addButton(FluidButton.of(fluid))
     open fun addResearch(research: Research) = addButton(ResearchButton(research))
 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/item/ItemIngredientsPage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/item/ItemIngredientsPage.kt
@@ -88,8 +88,8 @@ open class ItemIngredientsPage(val input: FluidOrItem) : TabbedGuidePage {
         .addIngredient(
             'r',
             when (input) {
-                is FluidOrItem.Fluid -> FluidButton(input.amountMillibuckets, input.fluid)
-                is FluidOrItem.Item -> ItemButton(input.item)
+                is FluidOrItem.Fluid -> FluidButton.of(input.amountMillibuckets, input.fluid)
+                is FluidOrItem.Item -> ItemButton.of(input.item)
             }
         )
         .addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
@@ -107,13 +107,13 @@ private val AMOUNT_KEY = rebarKey("actual_amount")
 
 @Suppress("UnstableApiUsage")
 private fun fluidOrItemButton(fluidOrItem: FluidOrItem) = when (fluidOrItem) {
-    is FluidOrItem.Fluid -> FluidButton(listOf(fluidOrItem.fluid), fluidOrItem.amountMillibuckets) { stack ->
+    is FluidOrItem.Fluid -> FluidButton.of(fluidOrItem) { stack ->
         stack.editPdc { pdc ->
             pdc.set(AMOUNT_KEY, RebarSerializers.DOUBLE, fluidOrItem.amountMillibuckets)
         }
     }
 
-    is FluidOrItem.Item -> ItemButton(fluidOrItem.item) { stack, _ ->
+    is FluidOrItem.Item -> ItemButton.of(fluidOrItem.item) { stack, _ ->
         ItemStackBuilder.of(stack)
             .name(
                 Component.translatable(

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/research/ResearchItemsPage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/guide/pages/research/ResearchItemsPage.kt
@@ -15,7 +15,7 @@ import xyz.xenondevs.invui.item.Item
 class ResearchItemsPage(research: Research) : SimpleStaticGuidePage(
     KEY,
     research.unlocks.mapNotNull {
-        RebarRegistry.ITEMS[it]?.let { schema -> ItemButton(schema.getItemStack()) }
+        RebarRegistry.ITEMS[it]?.let { schema -> ItemButton.of(schema.getItemStack()) }
     }.toMutableList()
 ) {
 


### PR DESCRIPTION
Reasonings:
1. We need to filter out any possible null/empty values supplied to both, and if those are the only values supplied, we should always return an empty item, not a broken Item/Fluid Button, we can't do that if people are using a constructor
2. We effectively had 2 ways to do the same thing for multiple constructors (there was an of constructor & a real constructor that did the same thing), there should only be 1 way
3. Java nullability, (proxy issue of 1) because of how java nullability works, you could pass null in java to a kotlin nonnull vararg and it was valid, which would lead to a broken button being constructed, which can only be caught in an of constructor
4. Consistency (kinda the same as 2) using constructors sometimes and Button#of other times is weird & confusing