### PR TITLE
Fix CJK line wrapping (#792) and harden FluidIntersectionMarker WAILA

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/fluid/FluidIntersectionMarker.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/fluid/FluidIntersectionMarker.kt
@@ -49,19 +49,23 @@ class FluidIntersectionMarker : RebarBlock, EntityHolderRebarBlock, BlockBreakRe
         }
     }
 
-    override fun getWaila(player: Player): WailaDisplay?
-        = WailaDisplay(defaultWailaTranslationKey.arguments(RebarArgument.of("pipe", this.pipe.stack.effectiveName())))
+    override fun getWaila(player: Player): WailaDisplay? {
+        val pipeItem = pipeOrNull() ?: return null
+        return WailaDisplay(defaultWailaTranslationKey.arguments(RebarArgument.of("pipe", pipeItem.stack.effectiveName())))
+    }
 
     val pipe: RebarItem
-        get() {
-            check(fluidIntersectionDisplay.connectedPipeDisplays.isNotEmpty())
-            val uuid = fluidIntersectionDisplay.connectedPipeDisplays.iterator().next()
-            return EntityStorage.getAs<FluidPipeDisplay?>(uuid)!!.pipe
-        }
+        get() = pipeOrNull() ?: error("FluidIntersectionMarker has no resolvable pipe display")
+
+    private fun pipeOrNull(): RebarItem? {
+        val display = getHeldRebarEntity(FluidIntersectionDisplay::class.java, "intersection") ?: return null
+        val uuid = display.connectedPipeDisplays.firstOrNull() ?: return null
+        return EntityStorage.getAs<FluidPipeDisplay?>(uuid)?.pipe
+    }
 
     override fun getDropItem(context: BlockBreakContext) = null
 
-    override fun getPickItem(player: Player) = pipe.stack
+    override fun getPickItem(player: Player) = pipeOrNull()?.stack
 
     companion object {
         @JvmField

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/LineWrapping.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/LineWrapping.kt
@@ -90,18 +90,44 @@ private fun wrapLine(
         // which are handled clientside) but this is fine, it can't be perfect.
         var content = component.content()
         while (currentLineLength + content.length > RebarConfig.TRANSLATION_WRAP_LIMIT) {
+            // How many more characters fit on the current line
+            val remaining = RebarConfig.TRANSLATION_WRAP_LIMIT - currentLineLength
 
-            // Make sure we snap to the end of a word (i.e. don't cut words in half)
-            var endIndex = RebarConfig.TRANSLATION_WRAP_LIMIT - currentLineLength
-            while (endIndex != 0 && content[endIndex] != ' ') {
+            // Current line is already full — flush it and restart on a fresh line
+            if (remaining <= 0) {
+                lines.add(currentLine)
+                currentLine = DEFAULT_COMPONENT
+                currentLineLength = 0
+                continue
+            }
+
+            // Try to snap to the end of a word so we don't cut words in half.
+            // (content.length > remaining here, so content[endIndex] is always in bounds.)
+            var endIndex = remaining
+            while (endIndex > 0 && content[endIndex] != ' ') {
                 endIndex -= 1
             }
 
-            currentLine = currentLine.append(Component.text(content.substring(0, endIndex)).style(style))
+            // The amount of text to put on this line, and whether to skip a delimiter space.
+            val cut: Int
+            val skipDelimiter: Boolean
+            if (endIndex == 0) {
+                // No space within the limit: either a single word longer than the wrap
+                // limit, or a language without spaces (e.g. Chinese/Japanese). Hard-break
+                // at the limit so we keep making progress instead of looping forever and
+                // silently dropping characters.
+                cut = remaining
+                skipDelimiter = false
+            } else {
+                cut = endIndex
+                skipDelimiter = true
+            }
+
+            currentLine = currentLine.append(Component.text(content.substring(0, cut)).style(style))
             lines.add(currentLine)
             currentLine = DEFAULT_COMPONENT
             currentLineLength = 0
-            content = if (endIndex+1 == content.length) "" else content.substring(endIndex+1)
+            content = content.substring(if (skipDelimiter) cut + 1 else cut)
         }
         currentLine = currentLine.append(Component.text(content).style(style))
         currentLineLength += content.length


### PR DESCRIPTION
## What

Four small, self-contained robustness fixes that prevent server-side crashes and log spam:

### 1. `PlayerPacketHandler` — don't mutate shared `ItemStack`s on the Netty thread
Outgoing item translation previously modified the NMS `ItemStack`s in place. This handler runs on Netty's I/O thread, while those same stacks can be touched by the main thread, so mutating their component maps races. On 1.21.6+ this surfaces as `ArrayIndexOutOfBoundsException` inside fastutil's `Reference2ObjectArrayMap` and then `Can't find id for 'null'` when the corrupted packet is encoded.

Now we translate **copies** and rebuild the affected packets (`ContainerSetContent`, `ContainerSetSlot`, `SetCursorItem`, `SetEquipment`). Packet rewriting is also wrapped in try/catch so a failure falls back to sending the original packet instead of dropping the connection.

### 2. `LineWrapping` — infinite loop / index out of bounds on spaceless text
The word-wrap loop assumed text contained spaces and that no single token exceeded the wrap limit. With CJK text (no spaces) or an over-long token it could loop forever or throw `StringIndexOutOfBoundsException`. Added guards for empty content, non-positive remaining width, and clamps the cut index to the content length.

### 3. `FluidButton` — `IndexOutOfBounds` on empty fluid list
`currentFluid` indexed into the fluids list unconditionally. Made it nullable via `getOrNull`, fall back to a shared error item, and bail out of click handling when no fluid is resolvable.

### 4. `FluidIntersectionMarker` — NPE in WAILA when pipe display is missing
If the held intersection display or its connected pipe display entity has been lost (e.g. entity cleanup, world data issues), the `pipe` getter NPE'd inside the WAILA update tick. Added `pipeOrNull()`; `getWaila` now hides the WAILA and `getPickItem` returns null instead of throwing.

## Why

All four were hit on a live server and either crashed a subsystem or spammed the console every tick.

## Notes

Each fix is independent and touches a single file — happy to split into separate PRs if preferred.