### PR TITLE
Entity Storage Fixes

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/Rebar.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/Rebar.kt
@@ -239,6 +239,7 @@ object Rebar : JavaPlugin(), RebarAddon {
         PathfindRebarEntityHandler.register(this, pm)
         PiglinRebarEntityHandler.register(this, pm)
         ProjectileRebarEntityHandler.register(this, pm)
+        RemoveRebarEntityHandler.register(this, pm)
         ResurrectRebarEntityHandler.register(this, pm)
         SlimeRebarEntityHandler.register(this, pm)
         SpellcasterRebarEntityHandler.register(this, pm)

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/fluid/FluidEndpointDisplay.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/fluid/FluidEndpointDisplay.kt
@@ -3,10 +3,9 @@ package io.github.pylonmc.rebar.content.fluid
 import io.github.pylonmc.rebar.datatypes.RebarSerializers
 import io.github.pylonmc.rebar.entity.EntityStorage
 import io.github.pylonmc.rebar.entity.RebarEntity
-import io.github.pylonmc.rebar.entity.interfaces.DeathRebarEntityHandler
 import io.github.pylonmc.rebar.entity.display.ItemDisplayBuilder
 import io.github.pylonmc.rebar.entity.display.transform.TransformBuilder
-import io.github.pylonmc.rebar.event.RebarEntityDeathEvent
+import io.github.pylonmc.rebar.entity.interfaces.RemoveRebarEntityHandler
 import io.github.pylonmc.rebar.fluid.FluidManager
 import io.github.pylonmc.rebar.fluid.FluidPointType
 import io.github.pylonmc.rebar.fluid.VirtualFluidPoint
@@ -19,6 +18,7 @@ import org.bukkit.block.Block
 import org.bukkit.block.BlockFace
 import org.bukkit.entity.ItemDisplay
 import org.bukkit.event.EventPriority
+import org.bukkit.event.entity.EntityRemoveEvent
 import org.bukkit.persistence.PersistentDataContainer
 import java.util.*
 import kotlin.math.pow
@@ -27,7 +27,7 @@ import kotlin.math.sqrt
 /**
  * A 'endpoint display' is one of the red/green displays that indicates a block's fluid input/output.
  */
-class FluidEndpointDisplay : RebarEntity<ItemDisplay>, DeathRebarEntityHandler, FluidPointDisplay {
+class FluidEndpointDisplay : RebarEntity<ItemDisplay>, RemoveRebarEntityHandler, FluidPointDisplay {
     override val point: VirtualFluidPoint
     var connectedPipeDisplay: UUID?
     override val connectedPipeDisplays: Set<UUID>
@@ -87,7 +87,7 @@ class FluidEndpointDisplay : RebarEntity<ItemDisplay>, DeathRebarEntityHandler, 
         })
     }
 
-    override fun onDeath(event: RebarEntityDeathEvent, priority: EventPriority) {
+    override fun onRemoved(event: EntityRemoveEvent, priority: EventPriority) {
         pipeDisplay?.delete(null, null)
         FluidManager.remove(point)
     }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/fluid/FluidIntersectionDisplay.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/fluid/FluidIntersectionDisplay.kt
@@ -4,10 +4,9 @@ import io.github.pylonmc.rebar.block.BlockStorage
 import io.github.pylonmc.rebar.datatypes.RebarSerializers
 import io.github.pylonmc.rebar.entity.EntityStorage
 import io.github.pylonmc.rebar.entity.RebarEntity
-import io.github.pylonmc.rebar.entity.interfaces.DeathRebarEntityHandler
 import io.github.pylonmc.rebar.entity.display.ItemDisplayBuilder
 import io.github.pylonmc.rebar.entity.display.transform.TransformBuilder
-import io.github.pylonmc.rebar.event.RebarEntityDeathEvent
+import io.github.pylonmc.rebar.entity.interfaces.RemoveRebarEntityHandler
 import io.github.pylonmc.rebar.fluid.FluidManager
 import io.github.pylonmc.rebar.fluid.FluidPointType
 import io.github.pylonmc.rebar.fluid.VirtualFluidPoint
@@ -19,13 +18,14 @@ import io.papermc.paper.datacomponent.item.CustomModelData
 import org.bukkit.block.Block
 import org.bukkit.entity.ItemDisplay
 import org.bukkit.event.EventPriority
+import org.bukkit.event.entity.EntityRemoveEvent
 import org.bukkit.persistence.PersistentDataContainer
 import java.util.*
 
 /**
  * A 'intersection display' is one of the gray displays that indicates one or more pipes being joined together.
  */
-class FluidIntersectionDisplay : RebarEntity<ItemDisplay>, DeathRebarEntityHandler, FluidPointDisplay {
+class FluidIntersectionDisplay : RebarEntity<ItemDisplay>, RemoveRebarEntityHandler, FluidPointDisplay {
     override val point: VirtualFluidPoint
     override val connectedPipeDisplays: MutableSet<UUID>
 
@@ -104,7 +104,7 @@ class FluidIntersectionDisplay : RebarEntity<ItemDisplay>, DeathRebarEntityHandl
         updateItemDisplay()
     }
 
-    override fun onDeath(event: RebarEntityDeathEvent, priority: EventPriority) {
+    override fun onRemoved(event: EntityRemoveEvent, priority: EventPriority) {
         FluidManager.remove(point)
     }
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/EntityStorage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/EntityStorage.kt
@@ -1,13 +1,12 @@
 package io.github.pylonmc.rebar.entity
 
-import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent
 import io.github.pylonmc.rebar.Rebar
 import io.github.pylonmc.rebar.addon.RebarAddon
 import io.github.pylonmc.rebar.block.BlockStorage
 import io.github.pylonmc.rebar.config.RebarConfig
 import io.github.pylonmc.rebar.event.RebarEntityAddEvent
-import io.github.pylonmc.rebar.event.RebarEntityDeathEvent
 import io.github.pylonmc.rebar.event.RebarEntityLoadEvent
+import io.github.pylonmc.rebar.event.RebarEntityRemoveEvent
 import io.github.pylonmc.rebar.event.RebarEntityUnloadEvent
 import io.github.pylonmc.rebar.registry.RebarRegistry
 import io.github.pylonmc.rebar.util.isFromAddon
@@ -18,8 +17,12 @@ import org.bukkit.Bukkit
 import org.bukkit.NamespacedKey
 import org.bukkit.entity.Entity
 import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
+import org.bukkit.event.entity.EntityDeathEvent
+import org.bukkit.event.entity.EntityRemoveEvent
 import org.bukkit.event.world.EntitiesLoadEvent
+import org.bukkit.event.world.EntitiesUnloadEvent
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantReadWriteLock
@@ -279,19 +282,13 @@ object EntityStorage : Listener {
         }
     }
 
-    // This currently does not differentiate between unloaded and dead entities because the API
-    // is broken (lol), hence the lack of an entity death listener
-    @EventHandler
-    private fun onEntityUnload(event: EntityRemoveFromWorldEvent) {
-        val rebarEntity = get(event.entity.uniqueId) ?: return
+    @EventHandler(priority = EventPriority.MONITOR)
+    private fun onEntityRemove(event: EntityRemoveEvent) {
+        if (event.cause == EntityRemoveEvent.Cause.UNLOAD) return
 
-        if (!event.entity.isDead) {
-            RebarEntity.serialize(rebarEntity)
-            rebarEntity.onUnload()
-            RebarEntityUnloadEvent(rebarEntity).callEvent()
-        } else {
-            RebarEntityDeathEvent(rebarEntity, event).callEvent()
-        }
+        val entity = event.entity
+        val rebarEntity = get(entity.uniqueId) ?: return
+        RebarEntityRemoveEvent(rebarEntity, event).callEvent()
 
         lockEntityWrite {
             entities.remove(rebarEntity.uuid)
@@ -303,12 +300,34 @@ object EntityStorage : Listener {
         }
     }
 
+    @EventHandler
+    private fun onEntityUnload(event: EntitiesUnloadEvent) {
+        for (entity in event.entities) {
+            val rebarEntity = get(entity.uniqueId) ?: return
+
+            RebarEntity.serialize(rebarEntity)
+            rebarEntity.onUnload()
+            RebarEntityUnloadEvent(rebarEntity).callEvent()
+
+            lockEntityWrite {
+                entities.remove(rebarEntity.uuid)
+                entitiesByKey[rebarEntity.schema.key]!!.remove(rebarEntity)
+                if (entitiesByKey[rebarEntity.schema.key]!!.isEmpty()) {
+                    entitiesByKey.remove(rebarEntity.schema.key)
+                }
+                entityAutosaveTasks.remove(rebarEntity.uuid)?.cancel()
+            }
+        }
+    }
+
     @JvmSynthetic
     internal fun cleanup(addon: RebarAddon) = lockEntityWrite {
         for ((_, value) in entitiesByKey.filter { it.key.isFromAddon(addon) }) {
             for (entity in value) {
                 try {
                     RebarEntity.serialize(entity)
+                    entity.onUnload()
+                    RebarEntityUnloadEvent(entity).callEvent()
                 } catch (e: Exception) {
                     Rebar.logger.severe("Error while unloading entity ${entity.uuid} (${entity.key}")
                     e.printStackTrace()
@@ -323,7 +342,15 @@ object EntityStorage : Listener {
     @JvmSynthetic
     internal fun cleanupEverything() {
         for (entity in entities.values) {
-            entity.write(entity.entity.persistentDataContainer)
+            RebarEntity.serialize(entity)
+            entity.onUnload()
+            RebarEntityUnloadEvent(entity).callEvent()
+        }
+
+        lockEntityWrite {
+            entities.clear()
+            entitiesByKey.clear()
+            entityAutosaveTasks.clear()
         }
     }
 

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/display/BlockDisplayBuilder.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/display/BlockDisplayBuilder.kt
@@ -47,6 +47,7 @@ open class BlockDisplayBuilder() {
     fun blockData(blockData: BlockData?): BlockDisplayBuilder = apply { this.blockData = blockData }
     fun transformation(transformation: Matrix4f?): BlockDisplayBuilder = apply { this.transformation = transformation }
     fun transformation(builder: TransformBuilder): BlockDisplayBuilder = apply { this.transformation = builder.buildForBlockDisplay() }
+    fun transformation(builder: (TransformBuilder) -> Unit) = transformation(TransformBuilder().apply(builder).build())
     fun brightness(brightness: Brightness): BlockDisplayBuilder = apply { this.brightness = brightness }
     fun brightness(brightness: Int): BlockDisplayBuilder = brightness(Brightness(0, brightness))
     fun glow(glowColor: Color?): BlockDisplayBuilder = apply { this.glowColor = glowColor }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/display/ItemDisplayBuilder.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/display/ItemDisplayBuilder.kt
@@ -11,6 +11,7 @@ import org.bukkit.entity.Display.Brightness
 import org.bukkit.entity.ItemDisplay
 import org.bukkit.inventory.ItemStack
 import org.joml.Matrix4f
+import java.util.function.Consumer
 
 
 @Suppress("unused")
@@ -50,6 +51,7 @@ open class ItemDisplayBuilder() {
     fun itemDisplayTransform(itemDisplayTransform: ItemDisplay.ItemDisplayTransform?) = apply { this.itemDisplayTransform = itemDisplayTransform }
     fun transformation(transformation: Matrix4f?) = apply { this.transformation = transformation }
     fun transformation(builder: TransformBuilder) = apply { this.transformation = builder.buildForItemDisplay() }
+    fun transformation(builder: Consumer<TransformBuilder>) = transformation(TransformBuilder().apply(builder::accept).build())
     fun brightness(brightness: Brightness) = apply { this.brightness = brightness }
     fun brightness(brightness: Int) = brightness(Brightness(0, brightness))
     fun glow(glowColor: Color?)  = apply { this.glowColor = glowColor }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/interfaces/RemoveRebarEntityHandler.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/interfaces/RemoveRebarEntityHandler.kt
@@ -6,24 +6,25 @@ import io.github.pylonmc.rebar.event.api.MultiListener
 import io.github.pylonmc.rebar.event.api.annotation.MultiHandlers
 import io.github.pylonmc.rebar.event.api.annotation.UniversalHandler
 import org.bukkit.event.EventPriority
-import org.bukkit.event.entity.EntityDeathEvent
+import org.bukkit.event.entity.EntityRemoveEvent
 import org.jetbrains.annotations.ApiStatus
 
-interface DeathRebarEntityHandler {
+interface RemoveRebarEntityHandler {
 
     /**
-     * Called when an entity dies
+     * Called when an entity is removed for any reason except unloading (use [UnloadRebarEntityHandler] for that)
      */
-    fun onDeath(event: EntityDeathEvent, priority: EventPriority) {}
+    fun onRemoved(event: EntityRemoveEvent, priority: EventPriority) {}
 
     @ApiStatus.Internal
     companion object : MultiListener {
         @UniversalHandler
-        private fun onDeath(event: EntityDeathEvent, priority: EventPriority) {
+        private fun onRemoved(event: EntityRemoveEvent, priority: EventPriority) {
+            if (event.cause == EntityRemoveEvent.Cause.UNLOAD) return
             val rebarEntity = EntityStorage.get(event.entity)
-            if (rebarEntity is DeathRebarEntityHandler) {
+            if (rebarEntity is RemoveRebarEntityHandler) {
                 try {
-                    MultiHandlers.handleEvent(rebarEntity, "onDeath", event, priority)
+                    MultiHandlers.handleEvent(rebarEntity, "onRemoved", event, priority)
                 } catch (e: Exception) {
                     logEventHandleErr(event, e, rebarEntity)
                 }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/interfaces/TickingRebarEntity.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/interfaces/TickingRebarEntity.kt
@@ -6,8 +6,9 @@ import io.github.pylonmc.rebar.entity.EntityListener
 import io.github.pylonmc.rebar.entity.RebarEntity
 import io.github.pylonmc.rebar.entity.RebarEntitySchema
 import io.github.pylonmc.rebar.event.RebarEntityAddEvent
-import io.github.pylonmc.rebar.event.RebarEntityDeathEvent
+import io.github.pylonmc.rebar.event.RebarEntityRemoveEvent
 import io.github.pylonmc.rebar.event.RebarEntitySerializeEvent
+import io.github.pylonmc.rebar.event.RebarEntityUnloadEvent
 import io.github.pylonmc.rebar.util.delayTicks
 import io.github.pylonmc.rebar.util.rebarKey
 import kotlinx.coroutines.*
@@ -88,7 +89,7 @@ interface TickingRebarEntity {
         }
 
         @EventHandler
-        private fun onUnload(event: RebarEntitySerializeEvent) {
+        private fun onUnload(event: RebarEntityUnloadEvent) {
             val entity = event.rebarEntity
             if (entity is TickingRebarEntity) {
                 tickingEntities.remove(entity)?.job?.cancel()
@@ -96,7 +97,7 @@ interface TickingRebarEntity {
         }
 
         @EventHandler
-        private fun onDeath(event: RebarEntityDeathEvent) {
+        private fun onRemove(event: RebarEntityRemoveEvent) {
             val entity = event.rebarEntity
             if (entity is TickingRebarEntity) {
                 tickingEntities.remove(entity)?.job?.cancel()

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/event/RebarEntityRemoveEvent.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/event/RebarEntityRemoveEvent.kt
@@ -1,14 +1,14 @@
 package io.github.pylonmc.rebar.event
 
-import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent
 import io.github.pylonmc.rebar.entity.RebarEntity
 import org.bukkit.event.Event
 import org.bukkit.event.HandlerList
+import org.bukkit.event.entity.EntityRemoveEvent
 
 /**
  * Called when a [RebarEntity] is removed for any reason.
  */
-class RebarEntityDeathEvent(val rebarEntity: RebarEntity<*>, val event: EntityRemoveFromWorldEvent) : Event() {
+class RebarEntityRemoveEvent(val rebarEntity: RebarEntity<*>, val event: EntityRemoveEvent) : Event() {
 
     override fun getHandlers(): HandlerList
         = handlerList


### PR DESCRIPTION
Currently EntityStorage saves the entities on entity removal, however that behavior is undefined and there is no guarantee that those changes will be persisted, I've changed it to entity unload instead. I also renamed the RebarEntityDeathEvent to be RebarEntityRemoveEvent as the name was misleading, death is not the same as removal, removal can be caused by death, but it isn't implicitly bound to it.

Ive also updated the death handler to listen to the real death event, not ours
1. because its been renamed and like I said isnt just death
2. because our event is called on the monitor priority of the root event, so in effect all handlers of our event are forced into monitor priority, so by switching to the actual event and not our own, implementing classes can still listen at any priority

For those reasons the new handler i added for actually handling entity removal, also uses the real event, not ours