### PR TITLE
fix(guide): load contributors.yml from addon instead of rebar

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/util/RebarUtils.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/util/RebarUtils.kt
@@ -512,7 +512,7 @@ internal fun getContributors(addon: RebarAddon): List<ContributorConfig> {
         return cached
     }
 
-    val config = ConfigSection.fromResource(Rebar, "contributors.yml")
+    val config = ConfigSection.fromResource(addon.javaPlugin, "contributors.yml")
     val contributors = config?.get(
         "contributors",
         ConfigAdapter.LIST.from(ConfigAdapter.CONTRIBUTOR),


### PR DESCRIPTION
Contributors list is read from rebar, no matter what addon instance is provided. This causes all addons to show the same contributors list.