### PR TITLE
fix: use standard bcp 47 code from Locale to construct LanguageRange

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/RebarTranslator.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/RebarTranslator.kt
@@ -125,7 +125,7 @@ class RebarTranslator private constructor(private val addon: RebarAddon) : Trans
             val lookupList = LocaleUtils.localeLookupList(locale)
             lookupList.reversed()
                 .mapIndexed { index, value ->
-                    Locale.LanguageRange(value.toString().replace('_', '-'), (index + 1.0) / lookupList.size)
+                    Locale.LanguageRange(value.toLanguageTag(), (index + 1.0) / lookupList.size)
                 }
                 .sortedByDescending { it.weight }
         }


### PR DESCRIPTION
`Locale.toLanguageTag()` returns standard bcp 47 code, use it instead of manually constructing questionable language code for `LanguageRange`

Fixes #784 