### PR TITLE
Fix ticking entity startup and async texture lighting

### DIFF
--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/entity/BlockTextureEntityImpl.kt
@@ -365,6 +365,9 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
         return stateUpdated
     }
 
+    private fun CraftBlock.isChunkLoadedSafe(): Boolean =
+        world.isChunkLoaded(x shr 4, z shr 4)
+
     private fun calculateLightingOffset(): Vector3f {
         if (directLighting) {
             return ZERO_VECTOR
@@ -376,7 +379,7 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
         var brightestLight = 0.toByte()
         if (brightest !== ZERO_VECTOR) {
             val delegateBlock = block.block.getRelative(brightest.x.toInt(), brightest.y.toInt(), brightest.z.toInt()) as? CraftBlock
-            if (delegateBlock?.blockState?.hasLightingData ?: false) {
+            if (delegateBlock != null && delegateBlock.isChunkLoadedSafe() && delegateBlock.blockState.hasLightingData) {
                 brightestLight = delegateBlock.lightLevel
                 if (brightestLight >= 15) return brightest
                 brightestFace = IMMEDIATE_FACES.firstOrNull { it.modX == brightest.x.toInt() && it.modY == brightest.y.toInt() && it.modZ == brightest.z.toInt() }
@@ -386,7 +389,7 @@ class BlockTextureEntityImpl : BlockTextureEntity, SyncedDataHolder {
         for (face in IMMEDIATE_FACES) {
             if (brightestFace == face) continue
             val delegateBlock = block.block.getRelative(face) as? CraftBlock ?: continue
-            if (delegateBlock.blockState.hasLightingData) {
+            if (delegateBlock.isChunkLoadedSafe() && delegateBlock.blockState.hasLightingData) {
                 val light = delegateBlock.lightLevel
                 if (light > brightestLight) {
                     brightestLight = light

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/interfaces/TickingRebarEntity.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/interfaces/TickingRebarEntity.kt
@@ -121,11 +121,17 @@ interface TickingRebarEntity {
         private val dispatchers = mutableMapOf<RebarEntitySchema, CoroutineDispatcher>()
 
         private fun startTicker(tickingEntity: TickingRebarEntity) {
+            // Ensure the entity is present before assigning its ticking job. After
+            // deserialization, the dispatcher cache can skip isAsync for later
+            // entities with the same schema, leaving them absent from the map.
+            val data = tickingEntities.getOrPut(tickingEntity) {
+                TickingEntityData(RebarConfig.DEFAULT_TICK_INTERVAL, false, null)
+            }
             val dispatcher = dispatchers.getOrPut((tickingEntity as RebarEntity<*>).schema) {
                 if (tickingEntity.isAsync) Dispatchers.Default
                 else Rebar.mainThreadDispatcher
             }
-            tickingEntities[tickingEntity]?.job = Rebar.scope.launch(dispatcher) {
+            data.job = Rebar.scope.launch(dispatcher) {
                 while (true) {
                     delayTicks(tickingEntity.tickInterval.toLong())
                     try {


### PR DESCRIPTION
﻿## Summary
- Ensure deserialized ticking entities are present in the ticking map before assigning their coroutine job, so later entities sharing a schema still tick.
- Avoid reading neighbor block states for texture lighting when the neighbor chunk is not loaded, preventing async chunk-load deadlocks during culling.

## Testing
- `./gradlew.bat :rebar:compileKotlin :nms:compileKotlin`
