### PR TITLE
Fix type casting for inventoryView in addSlotChangedListener

### DIFF
--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessorImpl.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/NmsAccessorImpl.kt
@@ -227,7 +227,7 @@ object NmsAccessorImpl : NmsAccessor {
     override fun createBlockTextureEntity(block: RebarBlock): BlockTextureEntity = BlockTextureEntityImpl(block)
 
     override fun addSlotChangedListener(key: NamespacedKey, inventoryView: InventoryView, listener: NmsAccessor.SlotListener) {
-        val inventoryView = inventoryView as CraftInventoryView<*, *>
+        val inventoryView = inventoryView as? CraftInventoryView<*, *> ?: return
         inventoryView.handle.addSlotListener(KeyedContainerListener(CraftNamespacedKey.toMinecraft(key), listener))
     }
 


### PR DESCRIPTION
When open portable dustbin or portable ender chest it will cause ClassCastException, so I just let it return null if cast class fail